### PR TITLE
RoutingError

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
     :controller => 'clearance/sessions',
     :only       => [:new, :create, :destroy]
 
-  resources :users, :controller => 'clearance/users' do
+  resources :users, :controller => 'clearance/users', :only => [:new, :create] do
     resource :password,
       :controller => 'clearance/passwords',
       :only       => [:create, :edit, :update]


### PR DESCRIPTION
If in app (rails 3.0.0) is resource :user, then method user_path evokes RoutingError: No route matches {:controller=>"clearance/users", :action=>"destroy"}.
