### PR TITLE
Email regular expression refactor

### DIFF
--- a/lib/clearance/user.rb
+++ b/lib/clearance/user.rb
@@ -50,7 +50,7 @@ module Clearance
         model.class_eval do
           validates_presence_of     :email, :unless => :email_optional?
           validates_uniqueness_of   :email, :case_sensitive => false, :allow_blank => true
-          validates_format_of       :email, :with => %r{.+@.+\..+}, :allow_blank => true
+          validates_format_of       :email, :with => %r{.+@.\w+(\.\w+)+}, :allow_blank => true
 
           validates_presence_of     :password, :unless => :password_optional?
           validates_confirmation_of :password


### PR DESCRIPTION
We are having troubles with actual regular expression since it allows emails like user@gmail....com, the user is registered successfully and it fails when is sending email because address is invalid.

The suggested regular expression is only a bit longer: /.+@.\w+(.\w+)+/
