### PR TITLE
User factory password confirmation

### DIFF
--- a/lib/rails/generators/clearance_templates/factories.rb
+++ b/lib/rails/generators/clearance_templates/factories.rb
@@ -5,7 +5,7 @@ end
 Factory.define :user do |user|
   user.email                 { Factory.next :email }
   user.password              { "password" }
-  user.password_confirmation { "password" }
+  user.password_confirmation { |instance| instance.password }
 end
 
 Factory.define :email_confirmed_user, :parent => :user do |user|

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -218,4 +218,10 @@ class UserTest < ActiveSupport::TestCase
     should allow_value("").for(:password)
   end
 
+  context "user factory" do
+    should "create a valid user with just an overridden password" do
+      assert Factory.build(:user, :password => "test").valid?
+    end
+  end
+
 end

--- a/test/rails_root/test/factories/clearance.rb
+++ b/test/rails_root/test/factories/clearance.rb
@@ -5,7 +5,7 @@ end
 Factory.define :user do |user|
   user.email                 { Factory.next :email }
   user.password              { "password" }
-  user.password_confirmation { "password" }
+  user.password_confirmation { |instance| instance.password }
 end
 
 Factory.define :email_confirmed_user, :parent => :user do |user|


### PR DESCRIPTION
It drives me crazy every time I have to pass both password and password confirmation in a cucumber scenario. This fixes it so you can specify a password without confirming when using the factory.
