### PR TITLE
Found a bug in password resets

### DIFF
--- a/features/engine/visitor_resets_password.feature
+++ b/features/engine/visitor_resets_password.feature
@@ -15,6 +15,16 @@ Feature: Password reset
     Then I should see "instructions for changing your password"
     And a password reset message should be sent to "email@example.com"
 
+  Scenario: User is signed up updated his password and tries blank password and confirmation
+    Given I signed up with "email@example.com/password"
+    And I go to the password reset request page
+    And I fill in "Email address" with "email@example.com"
+    And I press "Reset password"
+    When I follow the password reset link sent to "email@example.com"
+    And I update my password with "/"
+    Then I should see an error message
+    And I should be signed out
+
   Scenario: User is signed up updated his password and types wrong confirmation
     Given I signed up with "email@example.com/password"
     And I go to the password reset request page

--- a/lib/clearance/user.rb
+++ b/lib/clearance/user.rb
@@ -35,6 +35,8 @@ module Clearance
       def self.included(model)
         model.class_eval do
           attr_accessor :password, :password_confirmation
+          private
+          attr_accessor :password_changing
         end
       end
     end
@@ -115,6 +117,7 @@ module Clearance
       # @example
       #   user.update_password('new-password', 'new-password')
       def update_password(new_password, new_password_confirmation)
+        self.password_changing     = true
         self.password              = new_password
         self.password_confirmation = new_password_confirmation
         if valid?
@@ -162,11 +165,11 @@ module Clearance
       end
 
       # True if the password has been set and the password is not being
-      # updated. Override to allow other forms of # authentication (username,
-      # facebook, etc).
+      # updated and we are not updating the password. Override to allow
+      # other forms of authentication (username, facebook, etc).
       # @return [Boolean] true if the password field can be left blank for this user
       def password_optional?
-        encrypted_password.present? && password.blank?
+        encrypted_password.present? && password.blank? && password_changing.blank?
       end
 
       def password_required?

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -180,6 +180,21 @@ class UserTest < ActiveSupport::TestCase
             assert_not_nil @user.confirmation_token
           end
         end
+
+        context 'try to update with blank password and confirmation' do
+          setup do
+            @user.update_password("", "")
+          end
+
+          should "not change encrypted password" do
+            assert_equal @user.encrypted_password,
+                         @old_encrypted_password
+          end
+
+          should "not clear confirmation token" do
+            assert_not_nil @user.confirmation_token
+          end
+        end
       end
     end
 


### PR DESCRIPTION
Your master seems to allow for setting a blank password on the password resets page if the password and confirmation are both left blank when submitting the form. Here'sone way to fix it.

Joel
