### PR TITLE
Hoptoad to Airbrake

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Rails authentication & authorization with email & password.
 
 [We have clearance, Clarence.](http://www.youtube.com/watch?v=fVq4_HhBK8Y)
 
-Clearance was extracted out of [Hoptoad](http://hoptoadapp.com).
+Clearance was extracted out of [Airbrake](http://airbrakeapp.com/).
 
 Help
 ----


### PR DESCRIPTION
Updated link in README.md from [Hoptoad](http://hoptoadapp.com) to [Airbrake](http://airbrakeapp.com).
