### PR TITLE
Fix deprecated call to When in engine feature step

### DIFF
--- a/features/step_definitions/engine/clearance_steps.rb
+++ b/features/step_definitions/engine/clearance_steps.rb
@@ -32,7 +32,7 @@ Given /^I sign in$/ do
 end
 
 When /^I sign in (?:with|as) "([^"]*)"$/ do |email|
-  When %{I sign in with "#{email}" and "password"}
+  step %{I sign in with "#{email}" and "password"}
 end
 
 When /^I sign in (?:with|as) "([^"]*)" and "([^"]*)"$/ do |email, password|


### PR DESCRIPTION
Eliminates deprecation warning when running Cucumber features from client app.

https://github.com/cucumber/cucumber/issues/68
