### PR TITLE
Fix a broken step definition

### DIFF
--- a/features/step_definitions/engine/clearance_steps.rb
+++ b/features/step_definitions/engine/clearance_steps.rb
@@ -28,8 +28,8 @@ end
 Given /^I sign in$/ do
   email = FactoryGirl.generate(:email)
   steps %{
-    I have signed up with "#{email}"
-    I sign in with "#{email}"
+    Given I have signed up with "#{email}"
+    And I sign in with "#{email}"
   }
 end
 


### PR DESCRIPTION
The "I sign in" step definition is broken, with the following error:

```
   Given I sign in                             # features/step_definitions/clearance/clearance_steps.rb:28
   Lexing error on line 2: '    I have signed up with "user1@example.com"'. See http://wiki.github.com/cucumber/gherkin/lexingerror for more information. (Gherkin::Lexer::LexingError)
   ./features/step_definitions/clearance/clearance_steps.rb:33:in `/^I sign in$/'
   features/visit_homepage.feature:12:in `Given I sign in'
```

This fixes the bug, as explained in issue #175.
