### PR TITLE
Use a released version of addressable in Gemfile.lock.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,7 +36,7 @@ GEM
     activesupport (3.2.6)
       i18n (~> 0.6)
       multi_json (~> 1.0)
-    addressable (2.3.1)
+    addressable (2.3.2)
     appraisal (0.4.1)
       bundler
       rake

--- a/gemfiles/3.0.15.gemfile.lock
+++ b/gemfiles/3.0.15.gemfile.lock
@@ -1,5 +1,5 @@
 PATH
-  remote: /home/mike/thoughtbot/clearance
+  remote: /Users/gabe/thoughtbot/open-source/clearance
   specs:
     clearance (1.0.0.rc1)
       bcrypt-ruby
@@ -36,7 +36,7 @@ GEM
       activemodel (= 3.0.15)
       activesupport (= 3.0.15)
     activesupport (3.0.15)
-    addressable (2.3.1)
+    addressable (2.3.2)
     appraisal (0.4.1)
       bundler
       rake
@@ -57,7 +57,7 @@ GEM
       rack-test (>= 0.5.4)
       selenium-webdriver (~> 2.0)
       xpath (~> 0.1.4)
-    childprocess (0.3.4)
+    childprocess (0.3.5)
       ffi (~> 1.0, >= 1.0.6)
     cucumber (1.2.1)
       builder (>= 2.1.2)
@@ -79,12 +79,12 @@ GEM
     factory_girl_rails (3.5.0)
       factory_girl (~> 3.5.0)
       railties (>= 3.0.0)
-    ffi (1.1.0)
+    ffi (1.1.5)
     gherkin (2.11.1)
       json (>= 1.4.6)
     i18n (0.5.0)
-    json (1.7.3)
-    libwebsocket (0.1.4)
+    json (1.7.4)
+    libwebsocket (0.1.5)
       addressable
     mail (2.2.19)
       activesupport (>= 2.3.6)
@@ -125,7 +125,7 @@ GEM
       rspec-expectations (~> 2.11.0)
       rspec-mocks (~> 2.11.0)
     rspec-core (2.11.1)
-    rspec-expectations (2.11.1)
+    rspec-expectations (2.11.2)
       diff-lcs (~> 1.1.3)
     rspec-mocks (2.11.1)
     rspec-rails (2.11.0)

--- a/gemfiles/3.1.6.gemfile.lock
+++ b/gemfiles/3.1.6.gemfile.lock
@@ -1,5 +1,5 @@
 PATH
-  remote: /home/mike/thoughtbot/clearance
+  remote: /Users/gabe/thoughtbot/open-source/clearance
   specs:
     clearance (1.0.0.rc1)
       bcrypt-ruby
@@ -37,7 +37,7 @@ GEM
       activesupport (= 3.1.6)
     activesupport (3.1.6)
       multi_json (>= 1.0, < 1.3)
-    addressable (2.3.1)
+    addressable (2.3.2)
     appraisal (0.4.1)
       bundler
       rake
@@ -58,7 +58,7 @@ GEM
       rack-test (>= 0.5.4)
       selenium-webdriver (~> 2.0)
       xpath (~> 0.1.4)
-    childprocess (0.3.4)
+    childprocess (0.3.5)
       ffi (~> 1.0, >= 1.0.6)
     cucumber (1.2.1)
       builder (>= 2.1.2)
@@ -79,13 +79,13 @@ GEM
     factory_girl_rails (3.5.0)
       factory_girl (~> 3.5.0)
       railties (>= 3.0.0)
-    ffi (1.1.0)
+    ffi (1.1.5)
     gherkin (2.11.1)
       json (>= 1.4.6)
     hike (1.2.1)
     i18n (0.6.0)
-    json (1.7.3)
-    libwebsocket (0.1.4)
+    json (1.7.4)
+    libwebsocket (0.1.5)
       addressable
     mail (2.3.3)
       i18n (>= 0.4.0)
@@ -130,7 +130,7 @@ GEM
       rspec-expectations (~> 2.11.0)
       rspec-mocks (~> 2.11.0)
     rspec-core (2.11.1)
-    rspec-expectations (2.11.1)
+    rspec-expectations (2.11.2)
       diff-lcs (~> 1.1.3)
     rspec-mocks (2.11.1)
     rspec-rails (2.11.0)

--- a/gemfiles/3.2.6.gemfile.lock
+++ b/gemfiles/3.2.6.gemfile.lock
@@ -1,5 +1,5 @@
 PATH
-  remote: /home/mike/thoughtbot/clearance
+  remote: /Users/gabe/thoughtbot/open-source/clearance
   specs:
     clearance (1.0.0.rc1)
       bcrypt-ruby
@@ -36,7 +36,7 @@ GEM
     activesupport (3.2.6)
       i18n (~> 0.6)
       multi_json (~> 1.0)
-    addressable (2.3.1)
+    addressable (2.3.2)
     appraisal (0.4.1)
       bundler
       rake
@@ -57,7 +57,7 @@ GEM
       rack-test (>= 0.5.4)
       selenium-webdriver (~> 2.0)
       xpath (~> 0.1.4)
-    childprocess (0.3.4)
+    childprocess (0.3.5)
       ffi (~> 1.0, >= 1.0.6)
     cucumber (1.2.1)
       builder (>= 2.1.2)
@@ -78,14 +78,14 @@ GEM
     factory_girl_rails (3.5.0)
       factory_girl (~> 3.5.0)
       railties (>= 3.0.0)
-    ffi (1.1.0)
+    ffi (1.1.5)
     gherkin (2.11.1)
       json (>= 1.4.6)
     hike (1.2.1)
     i18n (0.6.0)
     journey (1.0.4)
-    json (1.7.3)
-    libwebsocket (0.1.4)
+    json (1.7.4)
+    libwebsocket (0.1.5)
       addressable
     mail (2.4.4)
       i18n (>= 0.4.0)
@@ -128,7 +128,7 @@ GEM
       rspec-expectations (~> 2.11.0)
       rspec-mocks (~> 2.11.0)
     rspec-core (2.11.1)
-    rspec-expectations (2.11.1)
+    rspec-expectations (2.11.2)
       diff-lcs (~> 1.1.3)
     rspec-mocks (2.11.1)
     rspec-rails (2.11.0)


### PR DESCRIPTION
addressable 2.3.1, the version to which the Gemfile was previously locked, has been yanked: https://rubygems.org/gems/addressable/versions .
