### PR TITLE
BCrypt migration strategy doesn't set password for use by Rails validation

### DIFF
--- a/lib/clearance/password_strategies/bcrypt.rb
+++ b/lib/clearance/password_strategies/bcrypt.rb
@@ -10,7 +10,6 @@ module Clearance
       end
 
       def password=(new_password)
-        set_password = new_password
         @password = new_password
 
         if new_password.present?

--- a/lib/clearance/password_strategies/bcrypt_migration_from_sha1.rb
+++ b/lib/clearance/password_strategies/bcrypt_migration_from_sha1.rb
@@ -26,7 +26,8 @@ module Clearance
       end
 
       def password=(new_password)
-        BCryptUser.new(self).password = @password = new_password
+        @password = new_password
+        BCryptUser.new(self).password = new_password
       end
 
       private


### PR DESCRIPTION
Hey Folks.

I ran into a bug after I upgraded a project to master with the BCrypt migration strategy. As it turns out, because of the way the modules are included, I don't believe that the password instance variable is being set correctly within the module. I took the easy way out and just set the password in the BCrypt migration instead of rewriting the other strategies to write the variable on the instance of user (which felt less clean).

Let me know if you want me to make other changes.
