### PR TITLE
Can't run tests with latest version of bundler

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -166,7 +166,7 @@ DEPENDENCIES
   appraisal (= 0.4.1)
   aruba (= 0.4.11)
   bourne (= 1.1.2)
-  bundler (= 1.1.3)
+  bundler (~> 1.1.3)
   capybara (= 1.1.2)
   clearance!
   cucumber-rails (= 1.1.1)

--- a/clearance.gemspec
+++ b/clearance.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'appraisal', '0.4.1'
   s.add_development_dependency 'aruba', '0.4.11'
   s.add_development_dependency 'bourne', '1.1.2'
-  s.add_development_dependency 'bundler', '1.1.3'
+  s.add_development_dependency 'bundler', '~> 1.1.3'
   s.add_development_dependency 'capybara', '1.1.2'
   s.add_development_dependency 'cucumber-rails', '1.1.1'
   s.add_development_dependency 'database_cleaner', '0.8.0'

--- a/gemfiles/3.0.15.gemfile.lock
+++ b/gemfiles/3.0.15.gemfile.lock
@@ -158,7 +158,7 @@ DEPENDENCIES
   appraisal (= 0.4.1)
   aruba (= 0.4.11)
   bourne (= 1.1.2)
-  bundler (= 1.1.3)
+  bundler (~> 1.1.3)
   capybara (= 1.1.2)
   clearance!
   cucumber-rails (= 1.1.1)

--- a/gemfiles/3.1.6.gemfile.lock
+++ b/gemfiles/3.1.6.gemfile.lock
@@ -168,7 +168,7 @@ DEPENDENCIES
   appraisal (= 0.4.1)
   aruba (= 0.4.11)
   bourne (= 1.1.2)
-  bundler (= 1.1.3)
+  bundler (~> 1.1.3)
   capybara (= 1.1.2)
   clearance!
   cucumber-rails (= 1.1.1)

--- a/gemfiles/3.2.6.gemfile.lock
+++ b/gemfiles/3.2.6.gemfile.lock
@@ -166,7 +166,7 @@ DEPENDENCIES
   appraisal (= 0.4.1)
   aruba (= 0.4.11)
   bourne (= 1.1.2)
-  bundler (= 1.1.3)
+  bundler (~> 1.1.3)
   capybara (= 1.1.2)
   clearance!
   cucumber-rails (= 1.1.1)


### PR DESCRIPTION
bundle (install) doesn't work for me because I am using bundler 1.1.5 and clearance.gemspec specifies bundler 1.1.3.

```
[16:25:38] .../clearance (master) $ bundle
Fetching gem metadata from http://rubygems.org/........
Bundler could not find compatible versions for gem "bundler":
  In Gemfile:
    bundler (= 1.1.3) ruby

  Current Bundler version:
    bundler (1.1.5)

This Gemfile requires a different version of Bundler.
Perhaps you need to update Bundler by running `gem install bundler`?
```
