### PR TITLE
Don't expose the existence of a user when resetting

### DIFF
--- a/app/controllers/clearance/passwords_controller.rb
+++ b/app/controllers/clearance/passwords_controller.rb
@@ -9,11 +9,8 @@ class Clearance::PasswordsController < ApplicationController
     if user = find_user_for_create
       user.forgot_password!
       ::ClearanceMailer.change_password(user).deliver
-      render :template => 'passwords/create'
-    else
-      flash_failure_after_create
-      render :template => 'passwords/new'
     end
+    render :template => 'passwords/create'
   end
 
   def edit
@@ -60,12 +57,6 @@ class Clearance::PasswordsController < ApplicationController
     flash.now[:notice] = translate(:forbidden,
       :scope => [:clearance, :controllers, :passwords],
       :default => 'Please double check the URL or try submitting the form again.')
-  end
-
-  def flash_failure_after_create
-    flash.now[:notice] = translate(:unknown_email,
-      :scope => [:clearance, :controllers, :passwords],
-      :default => 'Unknown email.')
   end
 
   def flash_failure_after_update

--- a/app/views/passwords/create.html.erb
+++ b/app/views/passwords/create.html.erb
@@ -1,4 +1,4 @@
 <p>
-  You will receive an email within the next few minutes.
-  It contains instructions for changing your password.
+  If the specified account exists, you will receive an email within the next few
+  minutes. It contains instructions for changing your password.
 </p>

--- a/features/engine/visitor_resets_password.feature
+++ b/features/engine/visitor_resets_password.feature
@@ -6,7 +6,7 @@ Feature: Password reset
 
   Scenario: User is not signed up
     When I reset the password for "unknown.email@example.com"
-    Then I am told email is unknown
+    Then instructions for changing my password are not emailed
 
   Scenario: User is signed up and requests password reset
     Given I signed up with "email@example.com"

--- a/features/step_definitions/engine/clearance_steps.rb
+++ b/features/step_definitions/engine/clearance_steps.rb
@@ -54,6 +54,11 @@ When /^I reset the password for "(.*)"$/ do |email|
   click_button 'Reset password'
 end
 
+Then /^instructions for changing my password are not emailed$/ do
+  page.should have_content('instructions for changing your password')
+  assert ActionMailer::Base.deliveries.empty?
+end
+
 Then /^instructions for changing my password are emailed to "(.*)"$/ do |email|
   page.should have_content('instructions for changing your password')
   user = User.find_by_email!(email)

--- a/spec/controllers/passwords_controller_spec.rb
+++ b/spec/controllers/passwords_controller_spec.rb
@@ -53,8 +53,7 @@ describe Clearance::PasswordsController do
           ActionMailer::Base.deliveries.should be_empty
         end
 
-        it { should set_the_flash.to(/unknown email/i).now }
-        it { should render_template(:new) }
+        it { should render_template(:create) }
       end
     end
   end


### PR DESCRIPTION
If an anonymous visitor submits a "reset password" request, they get a different response based on whether or not the email exists in the database. This goes against best security practices:

https://wiki.mozilla.org/WebAppSec/Secure_Coding_Guidelines#Password_Reset_Functions
