### PR TITLE
Redirect to root_url after sign_out?

### DIFF
--- a/app/controllers/clearance/sessions_controller.rb
+++ b/app/controllers/clearance/sessions_controller.rb
@@ -38,6 +38,6 @@ class Clearance::SessionsController < ApplicationController
   end
 
   def url_after_destroy
-    sign_in_url
+    '/'
   end
 end


### PR DESCRIPTION
I think it would be better to redirect back to redirect to the`root_url` instead of redirecting to the `sign_in` page after signing out.
