### PR TITLE
Move all application text to locales file

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,8 @@ New for 1.0.0:
 * Improve security when changing password.
 * Replace Cucumber feature generator with RSpec + Capybara.
 * Remove Diesel dependency.
+* Add locales support.
+* PasswordsController `params[:user]` has changed to `params[:password_reset]` to avoid locale conflicts
 
 New for 0.16.2:
 

--- a/app/controllers/clearance/passwords_controller.rb
+++ b/app/controllers/clearance/passwords_controller.rb
@@ -25,7 +25,7 @@ class Clearance::PasswordsController < ApplicationController
   def update
     @user = find_user_for_update
 
-    if @user.update_password params[:user][:password]
+    if @user.update_password params[:password_reset][:password]
       sign_in @user
       redirect_to url_after_update
     else
@@ -56,13 +56,13 @@ class Clearance::PasswordsController < ApplicationController
   def flash_failure_when_forbidden
     flash.now[:notice] = translate(:forbidden,
       :scope => [:clearance, :controllers, :passwords],
-      :default => 'Please double check the URL or try submitting the form again.')
+      :default => t('flashes.failure_when_forbidden'))
   end
 
   def flash_failure_after_update
     flash.now[:notice] = translate(:blank_password,
       :scope => [:clearance, :controllers, :passwords],
-      :default => "Password can't be blank.")
+      :default => t('flashes.failure_after_update'))
   end
 
   def forbid_missing_token

--- a/app/controllers/clearance/sessions_controller.rb
+++ b/app/controllers/clearance/sessions_controller.rb
@@ -30,7 +30,7 @@ class Clearance::SessionsController < ApplicationController
   def flash_failure_after_create
     flash.now[:notice] = translate(:bad_email_or_password,
       :scope => [:clearance, :controllers, :sessions],
-      :default => %{Bad email or password. Are you trying to register a new account? <a href="#{sign_up_path}">Sign up</a>.}.html_safe)
+      :default => t('flashes.failure_after_create', :sign_up_path => sign_up_path).html_safe)
   end
 
   def url_after_create

--- a/app/views/clearance_mailer/change_password.html.erb
+++ b/app/views/clearance_mailer/change_password.html.erb
@@ -1,5 +1,5 @@
-Someone, hopefully you, requested we send you a link to change your password:
+<%= t('.introduction_paragraph') %>
 
 <%= edit_user_password_url(@user, :token => @user.confirmation_token.html_safe) %>
 
-If you didn't request this, ignore this email. Your password hasn't been changed.
+<%= t('.ending_paragraph') %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,9 +7,9 @@
 <body>
   <div id='header'>
     <% if signed_in? -%>
-      <%= link_to 'Sign out', sign_out_path, :method => :delete %>
+      <%= link_to t('.sign_out'), sign_out_path, :method => :delete %>
     <% else -%>
-      <%= link_to 'Sign in', sign_in_path %>
+      <%= link_to t('.sign_in'), sign_in_path %>
     <% end -%>
   </div>
 

--- a/app/views/passwords/create.html.erb
+++ b/app/views/passwords/create.html.erb
@@ -1,4 +1,1 @@
-<p>
-  You will receive an email within the next few minutes.
-  It contains instructions for changing your password.
-</p>
+<p><%= t '.description' %></p>

--- a/app/views/passwords/edit.html.erb
+++ b/app/views/passwords/edit.html.erb
@@ -1,18 +1,16 @@
-<h2>Change your password</h2>
+<h2><%= t '.title' %></h2>
 
-<p>
-  Your password has been reset. Choose a new password below.
-</p>
+<p><%= t '.description' %></p>
 
-<%= form_for :user,
+<%= form_for :password_reset,
       :url => user_password_path(@user, :token => @user.confirmation_token),
       :html => { :method => :put } do |form| %>
   <div class='password_field'>
-    <%= form.label :password, 'Choose password' %>
+    <%= form.label :password %>
     <%= form.password_field :password %>
   </div>
 
   <div class='submit_field'>
-    <%= form.submit 'Save this password' %>
+    <%= form.submit %>
   </div>
 <% end %>

--- a/app/views/passwords/new.html.erb
+++ b/app/views/passwords/new.html.erb
@@ -1,16 +1,14 @@
-<h2>Reset your password</h2>
+<h2><%= t '.title' %></h2>
 
-<p>
-  We will email you a link to reset your password.
-</p>
+<p><%= t '.description' %></p>
 
 <%= form_for :password, :url => passwords_path do |form| %>
   <div class='text_field'>
-    <%= form.label :email, 'Email address' %>
+    <%= form.label :email %>
     <%= form.text_field :email, :type => 'email' %>
   </div>
 
   <div class='submit_field'>
-    <%= form.submit 'Reset password' %>
+    <%= form.submit %>
   </div>
 <% end %>

--- a/app/views/sessions/_form.html.erb
+++ b/app/views/sessions/_form.html.erb
@@ -10,6 +10,6 @@
   </div>
 
   <div class='submit_field'>
-    <%= form.submit 'Sign in' %>
+    <%= form.submit %>
   </div>
 <% end %>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,13 +1,13 @@
-<h2>Sign in</h2>
+<h2><%= t '.title' %></h2>
 
 <%= render :partial => '/sessions/form' %>
 
 <ul>
   <li>
-    <%= link_to 'Sign up', sign_up_path %>
+    <%= link_to t('.sign_up'), sign_up_path %>
   </li>
 
   <li>
-    <%= link_to 'Forgot password?', new_password_path %>
+    <%= link_to t('.forgot_password'), new_password_path %>
   </li>
 </ul>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -2,5 +2,5 @@
 
 <%= form_for @user do |form| %>
   <%= render :partial => '/users/form', :object => form %>
-  <%= form.submit 'Sign up' %>
+  <%= form.submit %>
 <% end %>

--- a/config/locales/clearance.en.yml
+++ b/config/locales/clearance.en.yml
@@ -1,0 +1,42 @@
+en:
+  flashes:
+    failure_when_forbidden: Please double check the URL or try submitting the form again.
+    failure_after_update: Password can't be blank.
+    failure_after_create: Bad email or password. Are you trying to register a new account? <a href="%{sign_up_path}">Sign up</a>.
+  helpers:
+    submit:
+      password:
+        submit: Reset password
+      password_reset:
+        submit: Save this password
+      session:
+        submit: Sign in
+      user:
+        create: Sign up
+    label:
+      password:
+        email: Email address
+      password_reset:
+        password: Choose password
+  layouts:
+    application:
+      sign_in: Sign in
+      sign_out: Sign out
+  passwords:
+    create:
+      description: You will receive an email within the next few minutes. It contains instructions for changing your password.
+    edit:
+      title: Change your password
+      description: Your password has been reset. Choose a new password below.
+    new:
+      title: Reset your password
+      description: We will email you a link to reset your password.
+  sessions:
+    new:
+      title: Sign in
+      sign_up: Sign up
+      forgot_password: Forgot password?
+  clearance_mailer:
+    change_password:
+      beginning_paragraph: 'Someone, hopefully you, requested we send you a link to change your password:'
+      ending_paragraph: If you didn't request this, ignore this email. Your password hasn't been changed.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,14 +1,19 @@
 Rails.application.routes.draw do
-  resources :passwords, :controller => 'clearance/passwords',
+  resources :passwords,
+    :controller => 'clearance/passwords',
     :only => [:create, :new]
 
-  resource  :session, :controller => 'clearance/sessions',
+  resource :session,
+    :controller => 'clearance/sessions',
     :only => [:create, :new, :destroy]
 
-  resources :users, :controller => 'clearance/users', :only => [:create, :new] do
-    resource :password, :controller => 'clearance/passwords',
-      :only => [:create, :edit, :update]
-  end
+  resources :users,
+    :controller => 'clearance/users',
+    :only => [:create, :new] do
+      resource :password,
+        :controller => 'clearance/passwords',
+        :only => [:create, :edit, :update]
+    end
 
   match 'sign_in' => 'clearance/sessions#new', :as => 'sign_in'
   match 'sign_out' => 'clearance/sessions#destroy', :as => 'sign_out', :via => :delete

--- a/gemfiles/3.0.17.gemfile.lock
+++ b/gemfiles/3.0.17.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: /Users/harlow/Sites/clearance
   specs:
-    clearance (1.0.0.rc2)
+    clearance (1.0.0.rc3)
       bcrypt-ruby
       rails (>= 3.0)
 

--- a/gemfiles/3.1.8.gemfile.lock
+++ b/gemfiles/3.1.8.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: /Users/harlow/Sites/clearance
   specs:
-    clearance (1.0.0.rc2)
+    clearance (1.0.0.rc3)
       bcrypt-ruby
       rails (>= 3.0)
 

--- a/gemfiles/3.2.8.gemfile.lock
+++ b/gemfiles/3.2.8.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: /Users/harlow/Sites/clearance
   specs:
-    clearance (1.0.0.rc2)
+    clearance (1.0.0.rc3)
       bcrypt-ruby
       rails (>= 3.0)
 

--- a/lib/clearance.rb
+++ b/lib/clearance.rb
@@ -6,3 +6,9 @@ require 'clearance/user'
 require 'clearance/engine'
 require 'clearance/password_strategies'
 require 'clearance/constraints'
+
+module Clearance
+  def self.root
+    File.expand_path('../..', __FILE__)
+  end
+end

--- a/lib/generators/clearance/specs/templates/integration/clearance/visitor_resets_password_spec.rb
+++ b/lib/generators/clearance/specs/templates/integration/clearance/visitor_resets_password_spec.rb
@@ -23,6 +23,6 @@ feature 'Visitor resets password' do
   end
 
   def page_should_display_change_password_message
-    page.should have_content('instructions for changing your password')
+    page.should have_content I18n.t('passwords.create.description')
   end
 end

--- a/lib/generators/clearance/specs/templates/integration/clearance/visitor_signs_in_spec.rb
+++ b/lib/generators/clearance/specs/templates/integration/clearance/visitor_signs_in_spec.rb
@@ -37,6 +37,12 @@ feature 'Visitor signs in' do
   end
 
   def page_should_display_sign_in_error
-    page.should have_content('Bad email or password')
+    page.should have_content(failure_after_create_message)
   end
- end
+
+  def failure_after_create_message
+    Nokogiri::HTML(
+      I18n.t('flashes.failure_after_create', :sign_up_path => sign_up_path)
+    ).inner_text
+  end
+end

--- a/lib/generators/clearance/specs/templates/integration/clearance/visitor_updates_password_spec.rb
+++ b/lib/generators/clearance/specs/templates/integration/clearance/visitor_updates_password_spec.rb
@@ -22,7 +22,7 @@ feature 'Visitor updates password' do
     visit_password_reset_page_for user
     change_password_to ''
 
-    page.should have_content("Password can't be blank")
+    page.should have_content I18n.t('flashes.failure_after_update')
     user_should_be_signed_out
   end
 
@@ -41,7 +41,7 @@ feature 'Visitor updates password' do
   end
 
   def change_password_to(password)
-    fill_in 'Choose password', :with => password
-    click_button 'Save this password'
+    fill_in 'password_reset_password', :with => password
+    click_button I18n.t('helpers.submit.password_reset.submit')
   end
 end

--- a/lib/generators/clearance/specs/templates/support/integration/clearance_helpers.rb
+++ b/lib/generators/clearance/specs/templates/support/integration/clearance_helpers.rb
@@ -2,16 +2,16 @@ module Integration
   module ClearanceHelpers
     def sign_up_with(email, password)
       visit sign_up_path
-      fill_in 'Email', :with => email
-      fill_in 'Password', :with => password
-      click_button 'Sign up'
+      fill_in 'user_email', :with => email
+      fill_in 'user_password', :with => password
+      click_button I18n.t('helpers.submit.user.create')
     end
 
     def sign_in_with(email, password)
       visit sign_in_path
-      fill_in 'Email', :with => email
-      fill_in 'Password', :with => password
-      click_button 'Sign in'
+      fill_in 'session_email', :with => email
+      fill_in 'session_password', :with => password
+      click_button I18n.t('helpers.submit.session.submit')
     end
 
     def signed_in_user
@@ -23,15 +23,15 @@ module Integration
 
     def user_should_be_signed_in
       visit root_path
-      page.should have_content('Sign out')
+      page.should have_content I18n.t('layouts.application.sign_out')
     end
 
     def sign_out
-      click_link 'Sign out'
+      click_link I18n.t('layouts.application.sign_out')
     end
 
     def user_should_be_signed_out
-      page.should have_content('Sign in')
+      page.should have_content I18n.t('layouts.application.sign_in')
     end
 
     def user_with_reset_password
@@ -42,8 +42,8 @@ module Integration
 
     def reset_password_for(email)
       visit new_password_path
-      fill_in 'Email address', :with => email
-      click_button 'Reset password'
+      fill_in 'password_email', :with => email
+      click_button I18n.t('helpers.submit.password.submit')
     end
   end
 end

--- a/lib/generators/clearance/views/views_generator.rb
+++ b/lib/generators/clearance/views/views_generator.rb
@@ -11,10 +11,20 @@ module Clearance
         end
       end
 
+      def create_locales
+        locales.each do |locale|
+          copy_file locale
+        end
+      end
+
       private
 
       def views
         files_within_root('.', 'app/views/**/*.*')
+      end
+
+      def locales
+        files_within_root('.', 'config/locales/**/*.*')
       end
 
       def files_within_root(prefix, glob)

--- a/spec/controllers/passwords_controller_spec.rb
+++ b/spec/controllers/passwords_controller_spec.rb
@@ -101,7 +101,7 @@ describe Clearance::PasswordsController do
         @new_password = 'new_password'
         @user.encrypted_password.should_not == @new_password
         put :update, :user_id => @user, :token => @user.confirmation_token,
-          :user => { :password => @new_password }
+          :password_reset => { :password => @new_password }
         @user.reload
       end
 
@@ -123,7 +123,7 @@ describe Clearance::PasswordsController do
     describe 'on PUT to #update with blank password' do
       before do
         put :update, :user_id => @user.to_param, :token => @user.confirmation_token,
-          :user => { :password => '' }
+          :password_reset => { :password => '' }
         @user.reload
       end
 
@@ -147,9 +147,9 @@ describe Clearance::PasswordsController do
     describe 'on PUT to #update with an empty token after the user sets a password' do
       before do
         put :update, :user_id => @user.to_param, :token => @user.confirmation_token,
-          :user => { :password => 'good password' }
+          :password_reset => { :password => 'good password' }
         put :update, :user_id => @user.to_param, :token => [nil],
-          :user => { :password => 'new password' }
+          :password_reset => { :password => 'new password' }
       end
 
       it { should set_the_flash.to(/double check the URL/i).now }


### PR DESCRIPTION
Wanted to get a conversation started around the integration tests. What's our best practice there? use the I18n translations for labels, fiels, etc. Or reference fields and buttons by `#id_name` and `.class_name` when using `fill_in` and other Capybara DSL
