### PR TITLE
BCryptMigrationFromSHA1: Make sure we save the password after encrypting it to Bcrypt

### DIFF
--- a/lib/clearance/password_strategies/bcrypt_migration_from_sha1.rb
+++ b/lib/clearance/password_strategies/bcrypt_migration_from_sha1.rb
@@ -44,6 +44,7 @@ module Clearance
         if sha1_password?
           if SHA1User.new(self).authenticated? password
             self.password = password
+            self.save
             true
           end
         end

--- a/spec/models/bcrypt_migration_from_sha1_spec.rb
+++ b/spec/models/bcrypt_migration_from_sha1_spec.rb
@@ -45,6 +45,7 @@ describe Clearance::PasswordStrategies::BCryptMigrationFromSHA1 do
       before do
         subject.salt = salt
         subject.encrypted_password = sha1_hash
+        subject.stubs :save => true
       end
 
       it 'is authenticated' do
@@ -60,6 +61,11 @@ describe Clearance::PasswordStrategies::BCryptMigrationFromSHA1 do
         lambda {
           subject.authenticated? 'bad' + password
         }.should_not raise_error(BCrypt::Errors::InvalidHash)
+      end
+
+      it 'saves the subject to database' do
+        subject.authenticated? password
+        subject.should have_received(:save)
       end
     end
 


### PR DESCRIPTION
The `BCryptMigrationFromSHA1` password strategy wasn’t saving the generated Bcypt password to database, so SHA-1 users were never migrated to Bcrypt.

In this pull request, we call `save` on the `User` model in `authenticated_with_sha1?` right after assigning the Bcrypt-encrypted password to `encrypted_password`.

See also issue #236 where I described the issue.
