### PR TITLE
fix for file system order bug in linux/tddium

### DIFF
--- a/lib/generators/clearance/specs/templates/support/integration.rb
+++ b/lib/generators/clearance/specs/templates/support/integration.rb
@@ -1,3 +1,5 @@
+Dir[Rails.root.join("spec/support/integration/*.rb")].sort.each {|f| require f}
+
 RSpec.configure do |config|
   config.include Integration::ClearanceHelpers, :type => :request
   config.include Integration::ActionMailerHelpers, :type => :request


### PR DESCRIPTION
In order for clearance integration tests to work on linux systems (as used by tddium) you need to include all the integration helper files explicity since the sort order on the linux systems is not the same as on mac systems, and without it all specs will fail.
