### PR TITLE
specify HTTP verb on sign_in and sign_up

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,7 @@ Rails.application.routes.draw do
         :only => [:create, :edit, :update]
     end
 
-  match 'sign_in' => 'clearance/sessions#new', :as => 'sign_in'
+  match 'sign_in' => 'clearance/sessions#new', :as => 'sign_in', :via => :get
   match 'sign_out' => 'clearance/sessions#destroy', :as => 'sign_out', :via => :delete
-  match 'sign_up' => 'clearance/users#new', :as => 'sign_up'
+  match 'sign_up' => 'clearance/users#new', :as => 'sign_up', :via => :get
 end


### PR DESCRIPTION
I tried to clearance:install in an edge rails app and got:

```
/Users/irohiroki/.rbenv/versions/1.9.3-p362/lib/ruby/gems/1.9.1/bundler/gems/rails-6b18a79abe03/actionpack/lib/action_dispatch/routing/mapper.rb:72:in `initialize': You should not use the `match` method in your router without specifying an HTTP method. (RuntimeError)
If you want to expose your action to GET, use `get` in the router:
  Instead of: match "controller#action"  Do: get "controller#action"
```

This patch fixes the above issue.
