### PR TITLE
Improve UX of password reset

### DIFF
--- a/config/locales/clearance.en.yml
+++ b/config/locales/clearance.en.yml
@@ -1,45 +1,72 @@
 en:
   flashes:
-    failure_when_forbidden: Please double check the URL or try submitting the form again.
-    failure_after_update: Password can't be blank.
-    failure_after_create: Bad email or password. Are you trying to register a new account? <a href="%{sign_up_path}">Sign up</a>.
+    failure_when_forbidden:
+      'Please double check the URL or try submitting the form again.'
+    failure_after_update:
+      "Password can't be blank."
+    failure_after_create:
+      'Bad email or password. Are you trying to register a new account?
+       <a href="%{sign_up_path}">Sign up</a>.'
   helpers:
     submit:
       password:
-        submit: Reset password
+        submit:
+          'Reset password'
       password_reset:
-        submit: Save this password
+        submit:
+          'Save this password'
       session:
-        submit: Sign in
+        submit:
+          'Sign in'
       user:
-        create: Sign up
+        create:
+          'Sign up'
     label:
       password:
-        email: Email address
+        email:
+          'Email address'
       password_reset:
-        password: Choose password
+        password:
+          'Choose password'
   layouts:
     application:
-      sign_in: Sign in
-      sign_out: Sign out
+      sign_in:
+        'Sign in'
+      sign_out:
+        'Sign out'
   passwords:
     create:
-      description: You will receive an email within the next few minutes. It contains instructions for changing your password.
+      description:
+        'You will receive an email within the next few minutes.
+         It contains instructions for changing your password.'
     edit:
-      title: Change your password
-      description: Your password has been reset. Choose a new password below.
+      title:
+        'Change your password'
+      description:
+        'Your password has been reset. Choose a new password below.'
     new:
-      title: Reset your password
-      description: We will email you a link to reset your password.
+      title:
+        'Reset your password'
+      description:
+        'To be emailed a link to reset your password, please enter your email
+        address.'
   sessions:
     new:
-      title: Sign in
-      sign_up: Sign up
-      forgot_password: Forgot password?
+      title:
+        'Sign in'
+      sign_up:
+        'Sign up'
+      forgot_password:
+        'Forgot password?'
   users:
     new:
-      sign_in: Sign in
+      sign_in:
+        'Sign in'
   clearance_mailer:
     change_password:
-      beginning_paragraph: 'Someone, hopefully you, requested we send you a link to change your password:'
-      ending_paragraph: If you didn't request this, ignore this email. Your password hasn't been changed.
+      beginning_paragraph:
+        'Someone, hopefully you, requested we send you a link to change your
+         password:'
+      ending_paragraph:
+        "If you didn't request this, ignore this email. Your password hasn't
+         been changed."


### PR DESCRIPTION
As reported on:

https://github.com/thoughtbot/clearance/issues/250

By default, the text on the password reset page read:

> We will email you a link to reset your password.

This implies that the system is already in the process of sending an email,
and that no further action is required by the user. We have had multiple
users of our application fail to complete the password reset flow because of
this confusion.

Here's how these users got stuck:
- Visit the login page.
- Enter their email address and an incorrect password.
- The application denies login with "Bad email or password" error.
- User gives up and clicks "Forgot password?" link.
- Reset password page loads with the text "We will email you a link to
  reset your password.". User thinks they are done. (After all, they
  already provided their email address on the login page.)
- User never completes the reset password form. Telephones support
  complaining their password is not being reset.

Our fix was to change the password reset text to:

> To be emailed a link to reset your password, please enter your email
> address.
