### PR TITLE
Move password email delivery to private method

### DIFF
--- a/app/controllers/clearance/passwords_controller.rb
+++ b/app/controllers/clearance/passwords_controller.rb
@@ -10,8 +10,7 @@ class Clearance::PasswordsController < ApplicationController
   def create
     if user = find_user_for_create
       user.forgot_password!
-      email = ::ClearanceMailer.change_password(user)
-      deliver_email(email)
+      deliver_email(user)
     end
     render :template => 'passwords/create'
   end
@@ -39,8 +38,8 @@ class Clearance::PasswordsController < ApplicationController
 
   private
 
-  def deliver_email(email)
-    email.deliver
+  def deliver_email(user)
+    ::ClearanceMailer.change_password(user).deliver
   end
 
   def password_reset_params


### PR DESCRIPTION
This should allow users of Clearance to change the way the password email is delivered. You could, for example, background the email delivery.
