### PR TITLE
Use env[:clearance] instead of env[:session]

### DIFF
--- a/lib/clearance/back_door.rb
+++ b/lib/clearance/back_door.rb
@@ -35,7 +35,7 @@ module Clearance
 
       if user_id.present?
         user = ::User.find(user_id)
-        env[:session].sign_in(user)
+        env[:clearance].sign_in(user)
       end
     end
   end

--- a/spec/clearance/back_door_spec.rb
+++ b/spec/clearance/back_door_spec.rb
@@ -10,7 +10,7 @@ describe Clearance::BackDoor do
 
     result = back_door.call(env)
 
-    env[:session].should have_received(:sign_in).with(user)
+    env[:clearance].should have_received(:sign_in).with(user)
     result.should eq mock_app.call(env)
   end
 
@@ -20,7 +20,7 @@ describe Clearance::BackDoor do
 
     result = back_door.call(env)
 
-    env[:session].should have_received(:sign_in).never
+    env[:clearance].should have_received(:sign_in).never
     result.should eq mock_app.call(env)
   end
 
@@ -29,8 +29,8 @@ describe Clearance::BackDoor do
   end
 
   def env_for_user_id(user_id)
-    session = stub('session', sign_in: true)
-    Rack::MockRequest.env_for("/?as=#{user_id}").merge(session: session)
+    clearance = stub('clearance', sign_in: true)
+    Rack::MockRequest.env_for("/?as=#{user_id}").merge(clearance: clearance)
   end
 
   def mock_app


### PR DESCRIPTION
Because this test was passing before, but not actually working, I think
this also needs some sort of test to see if

```
Clearance::Session.new(env).signed_in?
```

is true, but I don't have time/knowledge about clearance to do that.

Tested this with `gem 'clearance', path: '/Users/caleb/code/clearance'`
in an app that was using a working BackDoor, and it passed the specs.
