### PR TITLE
Change instructions to recommend installing rc5

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Clearance is a Rails engine tested against [Rails 3.x](/Appraisals) on Ruby
 
 Include the gem in your Gemfile:
 
-    gem 'clearance', '1.0.0.rc2'
+    gem 'clearance', '1.0.0.rc5'
 
 Bundle:
 


### PR DESCRIPTION
The documentation says to install rc2.  However, rc2 doesn't include the generator for integration tests (SpecsGenerator).

Users will need to install a newer version of the gem to run:

```
rails generate clearance:specs
```

as is recommended in the [Optional Integration tests](https://github.com/thoughtbot/clearance#optional-integration-tests) section.

Alternatively, the documentation could recommend using:

```
gem 'clearance', :git => 'https://github.com/thoughtbot/clearance.git'
```
