### PR TITLE
Speed up tests for apps using clearance with bcrypt

### DIFF
--- a/lib/clearance/password_strategies/bcrypt.rb
+++ b/lib/clearance/password_strategies/bcrypt.rb
@@ -20,7 +20,19 @@ module Clearance
       private
 
       def encrypt(password)
-        ::BCrypt::Password.create(password)
+        ::BCrypt::Password.create(password, :cost => cost)
+      end
+
+      def cost
+        if test_environment?
+          ::BCrypt::Engine::MIN_COST
+        else
+          ::BCrypt::Engine::DEFAULT_COST
+        end
+      end
+
+      def test_environment?
+        defined?(::Rails) && ::Rails.env.test?
       end
     end
   end

--- a/spec/models/bcrypt_migration_from_sha1_spec.rb
+++ b/spec/models/bcrypt_migration_from_sha1_spec.rb
@@ -24,7 +24,7 @@ describe Clearance::PasswordStrategies::BCryptMigrationFromSHA1 do
     end
 
     it 'encrypts with BCrypt' do
-      BCrypt::Password.should have_received(:create).with(password)
+      BCrypt::Password.should have_received(:create).with(password, anything)
     end
 
     it 'sets the pasword on the subject' do

--- a/spec/models/bcrypt_spec.rb
+++ b/spec/models/bcrypt_spec.rb
@@ -11,15 +11,32 @@ describe Clearance::PasswordStrategies::BCrypt do
 
     before do
       BCrypt::Password.stubs :create => encrypted_password
-      subject.password = password
     end
 
     it 'encrypts the password into encrypted_password' do
+      subject.password = password
+
       subject.encrypted_password.should == encrypted_password
     end
 
-    it 'encrypts with BCrypt' do
-      BCrypt::Password.should have_received(:create).with(password)
+    it 'encrypts with BCrypt using default cost in non test environments' do
+      Rails.stubs :env => ActiveSupport::StringInquirer.new("production")
+
+      subject.password = password
+
+      BCrypt::Password.should have_received(:create).with(
+        password,
+        :cost => ::BCrypt::Engine::DEFAULT_COST
+      )
+    end
+
+    it 'encrypts with BCrypt using minimum cost in test environment' do
+      subject.password = password
+
+      BCrypt::Password.should have_received(:create).with(
+        password,
+        :cost => ::BCrypt::Engine::MIN_COST
+      )
     end
   end
 


### PR DESCRIPTION
If clearance detects that it's being run in the test environment, it
will lower the bcyrpt cost factor (essentially, how much it will sleep)
to the minimum.

On my machine, this change took the test suite time from ~30 seconds to ~7. Those results aren't typical. For whatever reason, bcrypt is just dog slow on my machine. However, other developers on the project saw their suite times go from ~10 to ~6 seconds.
