### PR TITLE
Add updating of bundler to Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ rvm:
   - 1.9.3
 before_install:
   - gem update --system
+  - gem update bundler
 before_script:
   - "bundle exec rake db:migrate"
 gemfile:


### PR DESCRIPTION
There was an issue where Travis build were erring, because their bundler version was `1.2.3` and we explicitly upgrade `rubygems` via travis.yml. Thus, the result was that `rubygems` 2.0 is no longer compatible with older bundler versions. Thus let's always grab the latest version of bundler for Travis builds.
