### PR TITLE
Remove `unloadable` from controllers

### DIFF
--- a/app/controllers/clearance/passwords_controller.rb
+++ b/app/controllers/clearance/passwords_controller.rb
@@ -1,8 +1,6 @@
 require 'active_support/deprecation'
 
 class Clearance::PasswordsController < ApplicationController
-  unloadable
-
   skip_before_filter :authorize, :only => [:create, :edit, :new, :update]
   before_filter :forbid_missing_token, :only => [:edit, :update]
   before_filter :forbid_non_existent_user, :only => [:edit, :update]

--- a/app/controllers/clearance/sessions_controller.rb
+++ b/app/controllers/clearance/sessions_controller.rb
@@ -1,6 +1,4 @@
 class Clearance::SessionsController < ApplicationController
-  unloadable
-
   skip_before_filter :authorize, :only => [:create, :new, :destroy]
   protect_from_forgery :except => :create
 

--- a/app/controllers/clearance/users_controller.rb
+++ b/app/controllers/clearance/users_controller.rb
@@ -1,6 +1,4 @@
 class Clearance::UsersController < ApplicationController
-  unloadable
-
   skip_before_filter :authorize, :only => [:create, :new]
   before_filter :redirect_to_root, :only => [:create, :new], :if => :signed_in?
 


### PR DESCRIPTION
They are causing circular dependencies in Rails 4 + Ruby 2:

https://github.com/thoughtbot/clearance/issues/276
