### PR TITLE
Fix link to contributors page in NEWS.md

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-Thank you to all the [contributors](/thoughtbot/clearance/contributors)!
+Thank you to all the [contributors](https://github.com/thoughtbot/clearance/contributors)!
 
 New for 1.0.0:
 


### PR DESCRIPTION
The link currently points to https://github.com/thoughtbot/clearance/blob/master/thoughtbot/clearance/contributors
