### PR TITLE
added option to make remember_token cookie secure

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Override any of the defaults in `config/initializers/clearance.rb`:
 
     Clearance.configure do |config|
       config.cookie_expiration = lambda { 1.year.from_now.utc }
+      config.secure_cookie = false
       config.mailer_sender = 'reply@example.com'
       config.password_strategy = Clearance::PasswordStrategies::BCrypt
       config.user_model = User

--- a/lib/clearance/configuration.rb
+++ b/lib/clearance/configuration.rb
@@ -1,10 +1,11 @@
 module Clearance
   class Configuration
-    attr_accessor :cookie_expiration, :mailer_sender, :password_strategy, :user_model
+    attr_accessor :cookie_expiration, :mailer_sender, :password_strategy, :user_model, :secure_cookie
 
     def initialize
       @cookie_expiration = lambda { 1.year.from_now.utc }
       @mailer_sender = 'reply@example.com'
+      @secure_cookie = false
     end
 
     def user_model

--- a/lib/clearance/session.rb
+++ b/lib/clearance/session.rb
@@ -12,6 +12,7 @@ module Clearance
           headers, REMEMBER_TOKEN_COOKIE,
           :value => current_user.remember_token,
           :expires => Clearance.configuration.cookie_expiration.call,
+          :secure => Clearance.configuration.secure_cookie,
           :path => '/'
         )
       end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 describe Clearance::Configuration do
+  after { restore_default_config }
+
   describe 'when no user_model_name is specified' do
     before do
       Clearance.configure do |config|
@@ -29,6 +31,29 @@ describe Clearance::Configuration do
 
     it 'is used instead of User' do
       Clearance.configuration.user_model.should == ::MyUser
+    end
+  end
+
+  describe 'when secure_cookie is set to true' do
+    before do
+      Clearance.configure do |config|
+        config.secure_cookie = true
+      end
+    end
+
+    it 'returns true' do
+      Clearance.configuration.secure_cookie.should be_true
+    end
+  end
+
+  describe 'when secure_cookie is not specified' do
+    before do
+      Clearance.configure do |config|
+      end
+    end
+
+    it 'defaults to false' do
+      Clearance.configuration.secure_cookie.should be_false
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,3 +25,8 @@ RSpec.configure do |config|
   config.mock_with :mocha
   config.use_transactional_fixtures = true
 end
+
+def restore_default_config
+  Clearance.configuration = nil
+  Clearance.configure {}
+end


### PR DESCRIPTION
This is important if you have an app running on HTTPS, otherwise the auth cookie is leaked when you visit a HTTP URL and can be intercepted. Even if your whole app is on HTTPS and http://app only redirects to https://app, the cookie would be leaked in that redirect request and it would be enough to hijack the user's account.
