### PR TITLE
Ignore hostnames in return_to

### DIFF
--- a/lib/clearance/authorization.rb
+++ b/lib/clearance/authorization.rb
@@ -44,6 +44,12 @@ module Clearance
     end
 
     def return_to
+      if return_to_url
+        URI.parse(return_to_url).path
+      end
+    end
+
+    def return_to_url
       session[:return_to] || params[:return_to]
     end
 

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -67,6 +67,20 @@ describe Clearance::SessionsController do
     end
   end
 
+  describe 'on POST to #create with good credentials and foreign host in the return url' do
+    before do
+      @user = create(:user)
+      @return_path = '/return/path'
+      @return_url = "http://badhost.example.com#{@return_path}"
+      post :create, :session => { :email => @user.email, :password => @user.password },
+        :return_to => @return_url
+    end
+
+    it 'only uses the path from the return url' do
+      should redirect_to(@return_path)
+    end
+  end
+
   describe 'on DELETE to #destroy given a signed out user' do
     before do
       sign_out


### PR DESCRIPTION
- Extracts the path from return_to URLs
- Prevents malicious offsite redirects from phishing links

See unresolved issue 5 from: 
http://blog.codeclimate.com/blog/2013/03/27/rails-insecure-defaults/
