### PR TITLE
Denied API requests respond with proper status code

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,8 @@ New for 1.0.0:
   environment).
 * Add `redirect_url` configuration option.
 * Add `secure_cookie` configuration option.
+* Unauthorized API requests return HTTP status 401 rather than a redirect
+  to the sign in page.
 
 New for 0.16.2 (May 11, 2012):
 

--- a/lib/clearance/authorization.rb
+++ b/lib/clearance/authorization.rb
@@ -13,6 +13,15 @@ module Clearance
     end
 
     def deny_access(flash_message = nil)
+      respond_to do |format|
+        format.html { redirect_html_request(flash_message) }
+        format.all { head :unauthorized }
+      end
+    end
+
+    protected
+
+    def redirect_html_request(flash_message)
       store_location
 
       if flash_message
@@ -25,8 +34,6 @@ module Clearance
         redirect_to url_after_denied_access_when_signed_out
       end
     end
-
-    protected
 
     def clear_return_to
       session[:return_to] = nil

--- a/spec/controllers/apis_controller_spec.rb
+++ b/spec/controllers/apis_controller_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+class ApisController < ActionController::Base
+  include Clearance::Controller
+
+  before_filter :authorize
+
+  respond_to :js
+
+  def show
+    render text: 'response'
+  end
+
+  protected
+
+  def authorize
+    deny_access 'Access denied.'
+  end
+end
+
+describe ApisController do
+  before do
+    Rails.application.routes.draw do
+      resource :api, only: [:show]
+    end
+  end
+
+  after do
+    Rails.application.reload_routes!
+  end
+
+  it 'responds with HTTP status code 401 when denied' do
+    get :show, format: :js
+    subject.should respond_with(:unauthorized)
+  end
+end


### PR DESCRIPTION
When an API (js, xml) request is denied, clearance should respond with
the proper HTTP status code rather than redirecting to sign_in or
sign_up.
