### PR TITLE
Remove user-controlled return_to parameter

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -29,6 +29,7 @@ New for 1.0.0:
 * Add `secure_cookie` configuration option.
 * Unauthorized API requests return HTTP status 401 rather than a redirect
   to the sign in page.
+* Remove support for supplying return_to value via request parameter.
 
 New for 0.16.2 (May 11, 2012):
 

--- a/lib/clearance/authorization.rb
+++ b/lib/clearance/authorization.rb
@@ -57,7 +57,7 @@ module Clearance
     end
 
     def return_to_url
-      session[:return_to] || params[:return_to]
+      session[:return_to]
     end
 
     def url_after_denied_access_when_signed_in

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -40,47 +40,6 @@ describe Clearance::SessionsController do
     end
   end
 
-  describe 'on POST to #create with good credentials and a request return url' do
-    before do
-      @user = create(:user)
-      @return_url = '/url_in_the_request'
-      post :create, :session => { :email => @user.email, :password  => @user.password },
-        :return_to => @return_url
-    end
-
-    it 'redirects to the return URL' do
-      should redirect_to(@return_url)
-    end
-  end
-
-  describe 'on POST to #create with good credentials and a session return url and request return url' do
-    before do
-      @user = create(:user)
-      @return_url = '/url_in_the_session'
-      @request.session[:return_to] = @return_url
-      post :create, :session => { :email => @user.email, :password => @user.password },
-        :return_to => '/url_in_the_request'
-    end
-
-    it 'redirects to the return url' do
-      should redirect_to(@return_url)
-    end
-  end
-
-  describe 'on POST to #create with good credentials and foreign host in the return url' do
-    before do
-      @user = create(:user)
-      @return_path = '/return/path'
-      @return_url = "http://badhost.example.com#{@return_path}"
-      post :create, :session => { :email => @user.email, :password => @user.password },
-        :return_to => @return_url
-    end
-
-    it 'only uses the path from the return url' do
-      should redirect_to(@return_path)
-    end
-  end
-
   describe 'on DELETE to #destroy given a signed out user' do
     before do
       sign_out


### PR DESCRIPTION
Despite steps taken in 52ebe7ecc5bf0ddcdf3ca0dc07e0160bec45767d, it is
possible for an attacker to construct a retrun_to parameter that would
redirect the user off-site. I can provide the details via email or in
campfire.

The session[:return_to] value does not seem to be similarly vulnerable.

The params[:return_to] parameter isn't actually used in the default
templates, and a search through the git history (to the best of my git
ability) shows that it never was. This means:
- it should be safe to remove
- it's unlikely any applications are exploitable.
- it's unlikely this change will cause incompatibilities.
