### PR TITLE
Reorder respond_to formats in deny_access

### DIFF
--- a/lib/clearance/authorization.rb
+++ b/lib/clearance/authorization.rb
@@ -14,14 +14,14 @@ module Clearance
 
     def deny_access(flash_message = nil)
       respond_to do |format|
-        format.html { redirect_html_request(flash_message) }
-        format.all { head :unauthorized }
+        format.any(:js, :json, :xml) { head :unauthorized }
+        format.any { redirect_request(flash_message) }
       end
     end
 
     protected
 
-    def redirect_html_request(flash_message)
+    def redirect_request(flash_message)
       store_location
 
       if flash_message


### PR DESCRIPTION
Only API requests should return a 401. Previously, a request for any
type that wasn't HTML would return a 401. This isn't desired in many
cases (for instance, PDF).

Ultimately this may be best as a configurable block, though this is a more sane default.
