### PR TITLE
Added ability to set remember cookie as HttpOnly for added security

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Override any of these defaults in `config/initializers/clearance.rb`:
 
     Clearance.configure do |config|
       config.cookie_expiration = lambda { 1.year.from_now.utc }
+      config.httponly = false
       config.secure_cookie = false
       config.mailer_sender = 'reply@example.com'
       config.password_strategy = Clearance::PasswordStrategies::BCrypt

--- a/lib/clearance/configuration.rb
+++ b/lib/clearance/configuration.rb
@@ -2,6 +2,7 @@ module Clearance
   class Configuration
     attr_accessor \
       :cookie_expiration,
+      :httponly,
       :mailer_sender,
       :password_strategy,
       :redirect_url,
@@ -10,6 +11,7 @@ module Clearance
 
     def initialize
       @cookie_expiration = lambda { 1.year.from_now.utc }
+      @httponly = false
       @mailer_sender = 'reply@example.com'
       @secure_cookie = false
       @redirect_url = '/'

--- a/lib/clearance/session.rb
+++ b/lib/clearance/session.rb
@@ -13,6 +13,7 @@ module Clearance
           :value => current_user.remember_token,
           :expires => Clearance.configuration.cookie_expiration.call,
           :secure => Clearance.configuration.secure_cookie,
+          :httponly => Clearance.configuration.httponly,
           :path => '/'
         )
       end

--- a/spec/clearance/session_spec.rb
+++ b/spec/clearance/session_spec.rb
@@ -38,6 +38,33 @@ describe Clearance::Session do
     session.current_user.should == user
   end
 
+  context 'if httponly is set' do
+    before do
+      Clearance.configuration.httponly = true
+      session.sign_in(user)
+    end
+
+    it 'sets a httponly cookie' do
+      session.add_cookie_to_headers(headers)
+
+      headers['Set-Cookie'].should =~ /remember_token=.+; HttpOnly/
+    end
+
+    after { restore_default_config }
+  end
+
+  context 'if httponly is not set' do
+    before do
+      session.sign_in(user)
+    end
+
+    it 'sets a standard cookie' do
+      session.add_cookie_to_headers(headers)
+
+      headers['Set-Cookie'].should_not =~ /remember_token=.+; HttpOnly/
+    end
+  end
+
   it 'sets a remember token cookie with a default expiration of 1 year from now' do
     user = create(:user)
     headers = {}


### PR DESCRIPTION
Cookies should be marked as HttpOnly for added security, otherwise persisted XSS could expose the cookie to a 3rd party.  SSL is definitely a deterrent, but wouldn't solve this.
