### PR TITLE
Update the docs to show that Clearance does not handle flash messages with Users#create

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,11 @@ Rack applications can interact with it:
       end
     end
 
+Clearance does not display flash messages for Users#create. You
+will be responsible for providing this functionality. A common work flow is to use
+a form builder that handles this for you. Popular options are [Simple
+Form](https://github.com/plataformatec/simple_form) or [Formtastic](https://github.com/justinfrench/formtastic).
+
 Overriding routes
 -----------------
 


### PR DESCRIPTION
I had to do some digging before I realized that Clearance doesn't handle flash messages for creation like it does for other interactions. I would have liked the documentation to reflect this, so I added it.

Hopefully, this will be useful for others using Clearance.

Issue that led me to make the change: https://github.com/thoughtbot/clearance/issues/204?source=cc
