### PR TITLE
Explicitly signout user from BackDoor

### DIFF
--- a/lib/clearance/back_door.rb
+++ b/lib/clearance/back_door.rb
@@ -34,8 +34,12 @@ module Clearance
       user_id = params['as']
 
       if user_id.present?
-        user = Clearance.configuration.user_model.find(user_id)
-        env[:clearance].sign_in(user)
+        if user_id == 'signed_out'
+          env[:clearance].sign_out
+        else
+          user = Clearance.configuration.user_model.find(user_id)
+          env[:clearance].sign_in(user)
+        end
       end
     end
   end


### PR DESCRIPTION
In nested rspec examples, after visiting a route using Clearance's backdoor, all future page visits would still have the user signed in. This is good behavior, but I also needed a way to explicitly sign out that user.

This PR lets you do:

```
visit foo_route(as: :signed_ou)
```
