### PR TITLE
Drop TravisCI support for Ruby 1.9.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 rvm:
-  - 1.9.2
   - 1.9.3
   - 2.0.0
 before_script:

--- a/Appraisals
+++ b/Appraisals
@@ -1,8 +1,4 @@
-if RUBY_VERSION >= '1.9.3'
-  rails_versions = ['~> 3.2.13', '~> 4.0.0']
-else
-  rails_versions = ['~> 3.1.12']
-end
+rails_versions = ['~> 3.2.13', '~> 4.0.0']
 
 rails_versions.each do |rails_version|
   appraise "rails#{rails_version.slice(/\d+\.\d+/)}" do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    clearance (1.0.0.rc7)
+    clearance (1.0.0.rc8)
       bcrypt-ruby
       email_validator (~> 1.4)
       rails (>= 3.1)


### PR DESCRIPTION
- [There were issues](https://travis-ci.org/thoughtbot/clearance/jobs/9306920) with activesupport 4 and Ruby 1.9.2.
- Ignore Gemfile.lock. [This is standard](http://yehudakatz.com/2010/12/16/clarifying-the-roles-of-the-gemspec-and-gemfile/) when generating a new gem with `bundle gem`.
