### PR TITLE
Fix code injection in pre-existing User model

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ It works with Rails 4 and Ruby 2.
 Include the gem in your Gemfile:
 
 ```ruby
-gem 'clearance', '1.0.0.rc7'
+gem 'clearance', '1.0.0.rc8'
 ```
 
 Bundle:
@@ -57,11 +57,11 @@ Override any of these defaults in `config/initializers/clearance.rb`:
 Clearance.configure do |config|
   config.cookie_expiration = lambda { 1.year.from_now.utc }
   config.httponly = false
-  config.secure_cookie = false
   config.mailer_sender = 'reply@example.com'
   config.password_strategy = Clearance::PasswordStrategies::BCrypt
-  config.user_model = User
   config.redirect_url = '/'
+  config.secure_cookie = false
+  config.user_model = User
 end
 ```
 

--- a/lib/generators/clearance/install/install_generator.rb
+++ b/lib/generators/clearance/install/install_generator.rb
@@ -21,7 +21,11 @@ module Clearance
 
       def create_or_inject_clearance_into_user_model
         if File.exists? 'app/models/user.rb'
-          inject_into User, 'app/models/user.rb', 'include Clearance::User'
+          inject_into_file(
+            'app/models/user.rb',
+            "include Clearance::User\n\n",
+            after: "class User < ActiveRecord::Base\n"
+          )
         else
           copy_file 'user.rb', 'app/models/user.rb'
         end


### PR DESCRIPTION
On Rails 4 projects that already had an existing `User` model, the
`Clearance::User` module was not being injected correctly. The migration
and `Clearance::Controller` bits ran perfectly. Only this part was
flawed.

Minor:
- Update README.
- Alphabetize.
