### PR TITLE
Upgrade shoulda-matchers (rails 4 branch)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/thoughtbot/shoulda-matchers.git
-  revision: 2b452d5d3970e7319d0d4ea82942960616e05453
+  revision: da22d329067416ff851744a315197c6a44595dc2
   branch: dp-rails-four
   specs:
     shoulda-matchers (2.2.0)
@@ -49,7 +49,7 @@ GEM
       childprocess (>= 0.3.6)
       cucumber (>= 1.1.1)
       rspec-expectations (>= 2.7.0)
-    atomic (1.1.10)
+    atomic (1.1.13)
     bcrypt-ruby (3.1.1)
     bourne (1.5.0)
       mocha (>= 0.13.2, < 0.15)
@@ -87,7 +87,7 @@ GEM
     gherkin (2.12.0)
       multi_json (~> 1.3)
     hike (1.2.3)
-    i18n (0.6.4)
+    i18n (0.6.5)
     jbuilder (1.5.0)
       activesupport (>= 3.0.0)
       multi_json (>= 1.2.0)
@@ -101,7 +101,7 @@ GEM
     minitest (4.7.5)
     mocha (0.14.0)
       metaclass (~> 0.0.1)
-    multi_json (1.7.7)
+    multi_json (1.7.9)
     multi_test (0.0.2)
     nokogiri (1.6.0)
       mini_portile (~> 0.5.0)


### PR DESCRIPTION
Last commit revision is no longer available
