### PR TITLE
Update shoulda matchers to latest RC

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,8 +13,6 @@ gem 'factory_girl_rails', '~> 4.2'
 gem 'jbuilder', '~> 1.2'
 gem 'rspec-rails', '~> 2.13'
 gem 'sdoc'
-gem 'shoulda-matchers',
-  github: 'thoughtbot/shoulda-matchers',
-  branch: 'dp-rails-four'
+gem 'shoulda-matchers', '~> 2.4.0.rc1'
 gem 'sqlite3', '~> 1.3'
 gem 'timecop', '~> 0.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,3 @@
-GIT
-  remote: git://github.com/thoughtbot/shoulda-matchers.git
-  revision: da22d329067416ff851744a315197c6a44595dc2
-  branch: dp-rails-four
-  specs:
-    shoulda-matchers (2.2.0)
-      activesupport (>= 3.0.0)
-
 PATH
   remote: .
   specs:
@@ -145,6 +137,8 @@ GEM
       multi_json (~> 1.0)
       rubyzip
       websocket (~> 1.0.4)
+    shoulda-matchers (2.4.0.rc1)
+      activesupport (>= 3.0.0)
     sprockets (2.10.0)
       hike (~> 1.2)
       multi_json (~> 1.0)
@@ -184,6 +178,6 @@ DEPENDENCIES
   jbuilder (~> 1.2)
   rspec-rails (~> 2.13)
   sdoc
-  shoulda-matchers!
+  shoulda-matchers (~> 2.4.0.rc1)
   sqlite3 (~> 1.3)
   timecop (~> 0.6)


### PR DESCRIPTION
The rails 4 branch of shoulda matchers was merged in and a release candidate
was cut. Let's use that.
