### PR TITLE
Don't set cookie over HTTP if secure cookie is on

### DIFF
--- a/lib/clearance/rack_session.rb
+++ b/lib/clearance/rack_session.rb
@@ -8,7 +8,7 @@ module Clearance
       session = Clearance::Session.new(env)
       env[:clearance] = session
       response = @app.call(env)
-      session.add_cookie_to_headers response[1]
+      session.add_cookie_to_headers(response[1], env['HTTPS'])
       response
     end
   end

--- a/spec/clearance/rack_session_spec.rb
+++ b/spec/clearance/rack_session_spec.rb
@@ -19,6 +19,6 @@ describe Clearance::RackSession do
     Clearance::Session.should have_received(:new).with(env)
     response.body.should == expected_session
     expected_session.should have_received(:add_cookie_to_headers).
-      with(has_entries(headers))
+      with(has_entries(headers), Clearance::Session::SSL_OFF)
   end
 end

--- a/spec/clearance/session_spec.rb
+++ b/spec/clearance/session_spec.rb
@@ -101,10 +101,16 @@ describe Clearance::Session do
       session.sign_in(user)
     end
 
-    it 'sets a secure cookie' do
-      session.add_cookie_to_headers(headers)
+    it 'sets a secure cookie for https requests' do
+      session.add_cookie_to_headers(headers, Clearance::Session::SSL_ON)
 
       headers['Set-Cookie'].should =~ /remember_token=.+; secure/
+    end
+
+    it 'does not set a cookie for http requests' do
+      session.add_cookie_to_headers(headers, Clearance::Session::SSL_OFF)
+
+      headers['Set-Cookie'].should be_nil
     end
 
     after { restore_default_config }
@@ -115,8 +121,14 @@ describe Clearance::Session do
       session.sign_in(user)
     end
 
-    it 'sets a standard cookie' do
-      session.add_cookie_to_headers(headers)
+    it 'sets a standard cookie for https requests' do
+      session.add_cookie_to_headers(headers, Clearance::Session::SSL_ON)
+
+      headers['Set-Cookie'].should_not =~ /remember_token=.+; secure/
+    end
+
+    it 'sets a standard cookie for http requests' do
+      session.add_cookie_to_headers(headers, Clearance::Session::SSL_OFF)
 
       headers['Set-Cookie'].should_not =~ /remember_token=.+; secure/
     end


### PR DESCRIPTION
This fixes #338, but I'm not sold on the solution. I feel
like burdening Session with the HTTPS stuff breaks it's single
responsibility (it sets the cookie. period).

I'm going to try a second approach in another PR for comparison.
