### PR TITLE
Validate email using EmailValidator strict mode

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 Thank you to all the [contributors](https://github.com/thoughtbot/clearance/graphs/contributors)!
 
+New on Master:
+
+* Email validation is now done with `EmailValidator` [strict
+  mode](https://github.com/balexand/email_validator#strict-mode).
+
 New for 1.0.1 (August 9, 2013):
 
 * Fix an issue when trying to sign in with `nil`

--- a/lib/clearance/user.rb
+++ b/lib/clearance/user.rb
@@ -43,7 +43,7 @@ module Clearance
 
       included do
         validates :email,
-          email: true,
+          email: { strict_mode: true },
           presence: true,
           uniqueness: { allow_blank: true },
           unless: :email_optional?

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -9,11 +9,13 @@ describe User do
     it { should validate_presence_of(:password) }
     it { should allow_value('foo@example.co.uk').for(:email) }
     it { should allow_value('foo@example.com').for(:email) }
+    it { should allow_value('foo+bar@example.com').for(:email) }
     it { should_not allow_value('foo@').for(:email) }
     it { should_not allow_value('foo@example..com').for(:email) }
     it { should_not allow_value('foo@.example.com').for(:email) }
     it { should_not allow_value('foo').for(:email) }
     it { should_not allow_value('example.com').for(:email) }
+    it { should_not allow_value('foo;@example.com').for(:email) }
 
     it 'stores email in down case and removes whitespace' do
       user = create(:user, :email => 'Jo hn.Do e @exa mp le.c om')


### PR DESCRIPTION
Without strict_mode, EmailValidator allows addresses with unquoted special
characters, which can cause SMTP errors when delivery is attempted.

Why do we care? If the SMTP errors aren't enough, a user that typos an address
by mistakenly inserting a special character is unable to sign in again unless
they make the same typo.

strict_mode disallows most of these special characters, quoted or not, which
seems more appropriate than allowing them. When is the last time you saw an
address such as 'first";"last@gmail.com'.
