### PR TITLE
Added in sign in guards.

### DIFF
--- a/app/controllers/clearance/sessions_controller.rb
+++ b/app/controllers/clearance/sessions_controller.rb
@@ -5,12 +5,13 @@ class Clearance::SessionsController < ApplicationController
   def create
     @user = authenticate(params)
 
-    if @user.nil?
-      flash_failure_after_create
-      render :template => 'sessions/new', :status => :unauthorized
-    else
-      sign_in @user
-      redirect_back_or url_after_create
+    sign_in(@user) do |status|
+      if status.success?
+        redirect_back_or url_after_create
+      else
+        flash.now.notice = status.failure_message
+        render :template => 'sessions/new', :status => :unauthorized
+      end
     end
   end
 

--- a/lib/clearance.rb
+++ b/lib/clearance.rb
@@ -1,4 +1,5 @@
 require 'clearance/configuration'
+require 'clearance/sign_in_guard'
 require 'clearance/session'
 require 'clearance/rack_session'
 require 'clearance/back_door'

--- a/lib/clearance/authentication.rb
+++ b/lib/clearance/authentication.rb
@@ -25,11 +25,13 @@ module Clearance
     end
 
     def current_user=(user)
+      warn 'DEPRECATION WARNING: Assigning the current_user this way has been' +
+      ' deprecated. You should instead use the sign_in method.'
       clearance_session.sign_in user
     end
 
-    def sign_in(user)
-      clearance_session.sign_in user
+    def sign_in(user, &block)
+      clearance_session.sign_in user, &block
     end
 
     def sign_out

--- a/lib/clearance/configuration.rb
+++ b/lib/clearance/configuration.rb
@@ -7,7 +7,8 @@ module Clearance
       :password_strategy,
       :redirect_url,
       :secure_cookie,
-      :user_model
+      :user_model,
+      :sign_in_guards
 
     def initialize
       @cookie_expiration = ->(cookies) { 1.year.from_now.utc }
@@ -15,6 +16,7 @@ module Clearance
       @mailer_sender = 'reply@example.com'
       @secure_cookie = false
       @redirect_url = '/'
+      @sign_in_guards = []
     end
 
     def user_model

--- a/lib/clearance/default_sign_in_guard.rb
+++ b/lib/clearance/default_sign_in_guard.rb
@@ -1,0 +1,19 @@
+module Clearance
+  class DefaultSignInGuard < SignInGuard
+    def call
+      if session.signed_in?
+        success
+      else
+        failure default_failure_message.html_safe
+      end
+    end
+
+    def default_failure_message
+      I18n.t("flashes.failure_after_create", :sign_up_path => sign_up_path)
+    end
+
+    def sign_up_path
+      Rails.application.routes.url_helpers.sign_up_path
+    end
+  end
+end

--- a/lib/clearance/session_status.rb
+++ b/lib/clearance/session_status.rb
@@ -1,0 +1,19 @@
+module Clearance
+  class SuccessStatus
+    def success?
+      true
+    end
+  end
+
+  class FailureStatus
+    attr_reader :failure_message
+
+    def initialize(failure_message)
+      @failure_message = failure_message
+    end
+
+    def success?
+      false
+    end
+  end
+end

--- a/lib/clearance/sign_in_guard.rb
+++ b/lib/clearance/sign_in_guard.rb
@@ -1,0 +1,36 @@
+require 'clearance/session_status'
+
+module Clearance
+  class SignInGuard
+    def initialize(session, stack = [])
+      @session = session
+      @stack = stack
+    end
+
+    def success
+      SuccessStatus.new
+    end
+
+    def failure(message)
+      FailureStatus.new(message)
+    end
+
+    def next_guard
+      stack.call
+    end
+
+
+    private
+    attr_reader :stack, :session
+
+
+    def signed_in?
+      session.signed_in?
+    end
+
+    def current_user
+      session.current_user
+    end
+
+  end
+end

--- a/spec/clearance/session_spec.rb
+++ b/spec/clearance/session_spec.rb
@@ -37,11 +37,94 @@ describe Clearance::Session do
       expect(session.current_user).to eq user
     end
 
+    context 'with a block' do
+      it 'passes the success status to the block when sign in succeeds' do
+        success_status = stub_status(Clearance::SuccessStatus, true)
+        success_lambda = stub_callable
+
+        session.sign_in build(:user), &success_lambda
+
+        expect(success_lambda).to have_been_called.with(success_status)
+      end
+
+      it 'passes the failure status to the block when sign in fails' do
+        failure_status = stub_status(Clearance::FailureStatus, false)
+        failure_lambda = stub_callable
+
+        session.sign_in nil, &failure_lambda
+
+        expect(failure_lambda).to have_been_called.with(failure_status)
+      end
+
+      def stub_status(status_class, success)
+        stub('status', success?: success).tap do |status|
+          status_class.stubs(new: status)
+        end
+      end
+
+      def stub_callable
+        lambda {}.tap do |callable|
+          callable.stubs(:call)
+        end
+      end
+    end
+
     context 'with nil argument' do
       it 'assigns current_user' do
         session.sign_in nil
 
         expect(session.current_user).to be_nil
+      end
+    end
+
+    context 'with a sign in stack' do
+
+      it 'runs the first guard' do
+        guard = stub_sign_in_guard(succeed: true)
+        user = build(:user)
+
+        session.sign_in user
+
+        expect(guard).to have_received(:call)
+      end
+
+      it 'will not sign in the user if the guard stack fails' do
+        stub_sign_in_guard(succeed: false)
+        user = build(:user)
+
+        session.sign_in user
+
+        expect(session.instance_variable_get("@cookies")).to be_nil
+        expect(session.current_user).to be_nil
+      end
+
+
+      def stub_sign_in_guard(options)
+        session_status = stub_status(options.fetch(:succeed))
+
+        stub('guard', call: session_status).tap do |guard|
+          Clearance.configuration.sign_in_guards << stub_guard_class(guard)
+        end
+      end
+
+      def stub_default_sign_in_guard
+        stub(:default_sign_in_guard).tap do |sign_in_guard|
+          Clearance::DefaultSignInGuard.stubs(:new).with(session).returns(sign_in_guard)
+        end
+      end
+
+      def stub_guard_class(guard)
+        stub(:guard_class).tap do |guard_class|
+          guard_class.stubs(:new).with(session, stub_default_sign_in_guard).returns(guard)
+        end
+      end
+
+      def stub_status(success)
+        stub('status', success?: success)
+      end
+
+      after do
+        Clearance.configuration.sign_in_guards = []
       end
     end
   end
@@ -190,6 +273,10 @@ describe Clearance::Session do
     end
 
     header['Set-Cookie']
+  end
+
+  def have_been_called
+    have_received(:call)
   end
 
   def with_custom_expiration(custom_duration)

--- a/spec/clearance/sign_in_guard_spec.rb
+++ b/spec/clearance/sign_in_guard_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+module Clearance
+  describe SignInGuard do
+    it 'handles success' do
+      sign_in_guard = SignInGuard.new(stub('session'))
+      status = stub('status')
+      SuccessStatus.stubs(:new).returns(status)
+
+      expect(sign_in_guard.success).to eq(status)
+    end
+
+    it 'handles failure' do
+      sign_in_guard = SignInGuard.new(stub('session'))
+      status = stub('status')
+      failure_message = "Failed"
+      FailureStatus.stubs(:new).with(failure_message).returns(status)
+
+      expect(sign_in_guard.failure(failure_message)).to eq(status)
+    end
+
+    it 'can proceed to the next guard' do
+      guards = stub('guards', call: true)
+      sign_in_guard = SignInGuard.new(stub('session'), guards)
+      sign_in_guard.next_guard
+      expect(guards).to have_received(:call)
+    end
+  end
+end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -10,7 +10,7 @@ describe Clearance::Configuration do
     end
 
     it 'defaults to User' do
-      Clearance.configuration.user_model.should == ::User
+      expect(Clearance.configuration.user_model).to eq ::User
     end
   end
 
@@ -30,7 +30,7 @@ describe Clearance::Configuration do
     end
 
     it 'is used instead of User' do
-      Clearance.configuration.user_model.should == ::MyUser
+      expect(Clearance.configuration.user_model).to eq ::MyUser
     end
   end
 
@@ -48,7 +48,7 @@ describe Clearance::Configuration do
     end
 
     it 'returns true' do
-      Clearance.configuration.secure_cookie.should be_true
+      expect(Clearance.configuration.secure_cookie).to be_true
     end
   end
 
@@ -59,13 +59,13 @@ describe Clearance::Configuration do
     end
 
     it 'defaults to false' do
-      Clearance.configuration.secure_cookie.should be_false
+      expect(Clearance.configuration.secure_cookie).to be_false
     end
   end
 
   describe 'when no redirect URL specified' do
     it 'should return "/" as redirect URL' do
-      Clearance::Configuration.new.redirect_url.should == '/'
+      expect(Clearance::Configuration.new.redirect_url).to eq '/'
     end
   end
 
@@ -85,7 +85,27 @@ describe Clearance::Configuration do
     end
 
     it 'should return new redirect URL' do
-      Clearance.configuration.redirect_url.should == new_redirect_url
+      expect(Clearance.configuration.redirect_url).to eq new_redirect_url
+    end
+  end
+
+  describe 'when specifying sign in guards' do
+    DummyGuard = Class.new
+
+    before do
+      Clearance.configure do |config|
+        config.sign_in_guards = [DummyGuard]
+      end
+    end
+
+    after do
+      Clearance.configure do |config|
+        config.sign_in_guards = []
+      end
+    end
+
+    it 'should return the stack with added guards' do
+      expect(Clearance.configuration.sign_in_guards).to eq [DummyGuard]
     end
   end
 end


### PR DESCRIPTION
Sign in guards provide you with fine-grained control over the process of
signing in a user. Each guard is run in order and will hand the session
off to the next guard in the process. Any guard may also choose to fail
the sign in process and provide a message explaining why. Additionally
you could immediately determine the sign in process was a success and
skip running additional guards.
