### PR TITLE
Find account record from resourceful route when user model is overridden

### DIFF
--- a/app/controllers/clearance/passwords_controller.rb
+++ b/app/controllers/clearance/passwords_controller.rb
@@ -51,7 +51,7 @@ class Clearance::PasswordsController < ApplicationController
 
   def find_user_by_id_and_confirmation_token
     Clearance.configuration.user_model.
-      find_by_id_and_confirmation_token params[:user_id], params[:token].to_s
+      find_by_id_and_confirmation_token params[user_model_identifier], params[:token].to_s
   end
 
   def find_user_for_create
@@ -99,5 +99,9 @@ class Clearance::PasswordsController < ApplicationController
 
   def url_after_update
     Clearance.configuration.redirect_url
+  end
+
+  def user_model_identifier
+    "#{Clearance.configuration.user_model.to_s.underscore.downcase}_id".to_sym
   end
 end

--- a/spec/controllers/passwords_controller_spec.rb
+++ b/spec/controllers/passwords_controller_spec.rb
@@ -1,6 +1,55 @@
 require 'spec_helper'
 
+class Person
+end
+
+class MultiWordHumanBeingKlass
+end
+
 describe Clearance::PasswordsController do
+
+  context "custom user model adaptations" do
+    before do
+      @original_user_model = Clearance.configuration.user_model
+    end
+    after do
+      Clearance.configuration.user_model = @original_user_model
+    end
+
+    context "when the user model is Person" do
+      describe "#user_model_identifier" do
+        before do
+          Clearance.configuration.user_model = Person
+        end
+
+        it "is :person_id" do
+          controller.send(:user_model_identifier).should eql(:person_id)
+        end
+      end
+    end
+
+    context "when the user model is MultiWordHumanBeingKlass" do
+      describe "#user_model_identifier" do
+        before do
+          Clearance.configuration.user_model = MultiWordHumanBeingKlass
+        end
+
+        it "is :person_id" do
+          controller.send(:user_model_identifier).should eql(:multi_word_human_being_klass_id)
+        end
+      end
+    end
+
+    context "when the user model is User" do
+      describe "#user_model_identifier" do
+        it "is :user_id" do
+          controller.send(:user_model_identifier).should eql(:user_id)
+        end
+      end
+    end
+  end
+
+
   describe 'a signed up user' do
     before do
       @user = create(:user)


### PR DESCRIPTION
The password reset function breaks when the user model is overridden, as the record ID from the resourceful route is expected to be available as `:user_id` but instead is e.g. `:person_id`

This corrects that.

I'm not wild about the dummy class definitions in the password controller spec file; suggestions for improving that aspect welcomed.
