### PR TITLE
Fix back_door.rb to remove Rack ENV discrepancies

### DIFF
--- a/lib/clearance/back_door.rb
+++ b/lib/clearance/back_door.rb
@@ -30,7 +30,9 @@ module Clearance
     private
 
     def sign_in_through_the_back_door(env)
-      params = Rack::Utils.parse_query(env['QUERY_STRING'])
+      request = Rack::Request.new env
+      params = request.params
+
       user_id = params['as']
 
       if user_id.present?


### PR DESCRIPTION
I was having incredible trouble with this helper and one of my request specs - POST request backdoor attempts were simply being ignored.

After debugging, I found that env['QUERY_STRING'] in the below context doesn't contain anything when POSTing. (With GET, this works perfectly)

So in line with Rails (and Ruby/Rack) idioms, I've refactored the middleware in the Rack-recommended way and now use Rack to properly chew through the query parameters, returning them in a clean, consistent fashion across request types.
