### PR TITLE
Remove reference to `bundle --binstubs`

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ gem 'clearance'
 
 Bundle:
 
-    bundle --binstubs
+    bundle install
 
 Make sure the development database exists. Then, run the generator:
 


### PR DESCRIPTION
- This clobbers bin/rails and other Rails builtins
- We're no longer using `--binstubs` on Rails projects

https://github.com/thoughtbot/clearance/issues/387
