### PR TITLE
Handle edge cases in sign_in test helper

### DIFF
--- a/lib/clearance/testing/helpers.rb
+++ b/lib/clearance/testing/helpers.rb
@@ -7,7 +7,15 @@ module Clearance
       end
 
       def sign_in
-        sign_in_as FactoryGirl.create(:user)
+        unless defined?(FactoryGirl)
+          raise(
+            RuntimeError,
+            "Clearance's `sign_in` helper requires factory_girl"
+          )
+        end
+
+        factory = Clearance.configuration.user_model.to_s.underscore.to_sym
+        sign_in_as FactoryGirl.create(factory)
       end
 
       def sign_in_as(user)

--- a/spec/clearance/testing/helpers_spec.rb
+++ b/spec/clearance/testing/helpers_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe Clearance::Testing::Helpers do
+  class TestClass
+    include Clearance::Testing::Helpers
+
+    def initialize
+      @controller = Controller.new
+    end
+
+    class Controller
+      def sign_in(user); end
+    end
+  end
+
+  describe '#sign_in' do
+    it 'creates an instance of the clearance user model with FactoryGirl' do
+      MyUserModel = Class.new
+      FactoryGirl.stubs(:create)
+      Clearance.configuration.stubs(user_model: MyUserModel)
+
+      TestClass.new.sign_in
+
+      expect(FactoryGirl).to have_received(:create).with(:my_user_model)
+    end
+  end
+end


### PR DESCRIPTION
The sign_in helper requires FactoryGirl to create a user. FactoryGirl isn't a
dependency of the Gem and we wouldn't want it to be because we don't want it
loaded in production. Raise a more helpful error if someone tries to use the
`sign_in` test helper without having FactoryGirl.

Additionally remove the hard-coded `:user` factory in favor of a factory named
for whatever the configred user model is.
