### PR TITLE
Remove SessionsController failure message override

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,11 @@
 Thank you to all the [contributors](https://github.com/thoughtbot/clearance/graphs/contributors)!
 
 New on Master:
+* Sign in failure message is now customized exclusively via I18n.
+  `SessionsController#flash_failure_after_create` is no longer called. To
+  customize the message, change the
+  `clearance.controllers.sessions.bad_email_or_password` or
+  `flashes.failure_after_create` key.
 * Sign in can now be disabled with `config.allow_sign_in = false`
 
 New for 1.1.0 (November 21, 2013):

--- a/README.md
+++ b/README.md
@@ -199,7 +199,6 @@ Or, override private methods:
     passwords#forbid_non_existent_user
     passwords#url_after_create
     passwords#url_after_update
-    sessions#flash_failure_after_create
     sessions#url_after_create
     sessions#url_after_destroy
     users#flash_failure_after_create

--- a/app/controllers/clearance/sessions_controller.rb
+++ b/app/controllers/clearance/sessions_controller.rb
@@ -26,12 +26,6 @@ class Clearance::SessionsController < ApplicationController
 
   private
 
-  def flash_failure_after_create
-    flash.now[:notice] = translate(:bad_email_or_password,
-      :scope => [:clearance, :controllers, :sessions],
-      :default => t('flashes.failure_after_create', :sign_up_path => sign_up_path).html_safe)
-  end
-
   def url_after_create
     Clearance.configuration.redirect_url
   end

--- a/lib/clearance/default_sign_in_guard.rb
+++ b/lib/clearance/default_sign_in_guard.rb
@@ -9,7 +9,14 @@ module Clearance
     end
 
     def default_failure_message
-      I18n.t("flashes.failure_after_create", :sign_up_path => sign_up_path)
+      I18n.t(
+        :bad_email_or_password,
+        scope: [:clearance, :controllers, :sessions],
+        default: I18n.t(
+          'flashes.failure_after_create',
+          sign_up_path: sign_up_path
+        ).html_safe
+      )
     end
 
     def sign_up_path

--- a/lib/clearance/sign_in_guard.rb
+++ b/lib/clearance/sign_in_guard.rb
@@ -19,10 +19,9 @@ module Clearance
       stack.call
     end
 
-
     private
-    attr_reader :stack, :session
 
+    attr_reader :stack, :session
 
     def signed_in?
       session.signed_in?
@@ -31,6 +30,5 @@ module Clearance
     def current_user
       session.current_user
     end
-
   end
 end


### PR DESCRIPTION
Since the introduction of the `SignInGaurd` stack, this method was no longer
being called. I moved it's implementation into the failure message used by the
`DefaultSignInGuard`. Customizing the message is done entirely via I18n.

Resolves #378
