### PR TITLE
Get user_model id parameter from configuration

### DIFF
--- a/app/controllers/clearance/passwords_controller.rb
+++ b/app/controllers/clearance/passwords_controller.rb
@@ -50,8 +50,10 @@ class Clearance::PasswordsController < ApplicationController
   end
 
   def find_user_by_id_and_confirmation_token
+    user_param = Clearance.configuration.user_id_parameter
+
     Clearance.configuration.user_model.
-      find_by_id_and_confirmation_token params[:user_id], params[:token].to_s
+      find_by_id_and_confirmation_token params[user_param], params[:token].to_s
   end
 
   def find_user_for_create

--- a/lib/clearance/configuration.rb
+++ b/lib/clearance/configuration.rb
@@ -40,6 +40,10 @@ module Clearance
         []
       end
     end
+
+    def user_id_parameter
+      "#{user_model.model_name.singular}_id".to_sym
+    end
   end
 
   def self.configuration

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -142,4 +142,13 @@ describe Clearance::Configuration do
       end
     end
   end
+
+  describe '#user_id_parameter' do
+    it 'returns the parameter key to use based on the user_model' do
+      CustomUser = Class.new(ActiveRecord::Base)
+      Clearance.configure { |config| config.user_model = CustomUser }
+
+      Clearance.configuration.user_id_parameter.should eq :custom_user_id
+    end
+  end
 end


### PR DESCRIPTION
The password reset controller was previously assuming that the id parameter
would be available as 'user_id', but if you have customized the user model
this won't be the case. Get the proper name from the configuration.

Supersedes #377
