### PR TITLE
Backfill remember_token for existing user records

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 Thank you to all the [contributors](https://github.com/thoughtbot/clearance/graphs/contributors)!
 
+New on MASTER
+* Installing Clearance with an existing User model will now add remember tokens
+  to all user records.
+
 New for 1.2.1 (March 6, 2014):
 * Query string is now included in the redirect URL when Clearance redirects to a
   previously stored URL.

--- a/features/add_migrations_to_project.feature
+++ b/features/add_migrations_to_project.feature
@@ -14,14 +14,15 @@ Feature: add migrations to the project
 
   Scenario: Users table without clearance fields exists in the database
     When I install dependencies
-    And I create a simple migration
-    And I successfully run `bundle exec rake db:migrate`
+    And I create a simple user model
+    And I add an existing user
     And I successfully run `bundle exec rails generate clearance:install`
-    And I successfully run `ls db/migrate`
+    And I successfully run `bundle exec rake db:migrate`
     Then the output should contain:
       """
       add_clearance_to_users.rb
       """
+    And the existing user should have a remember token
 
   Scenario: Users table with clearance fields exists in the database
     When I install dependencies

--- a/features/step_definitions/configuration_steps.rb
+++ b/features/step_definitions/configuration_steps.rb
@@ -89,21 +89,26 @@ When /^I configure test-unit$/ do
   }
 end
 
-When /^I create a simple migration$/ do
+When /^I create a simple user model$/ do
   steps %Q{
-    When I write to "db/migrate/001_create_users.rb" with:
-      """
-      class CreateUsers < ActiveRecord::Migration
-        def self.up
-          create_table(:users) do |t|
-            t.string :email
-            t.string :name
-          end
-        end
-        def self.down
-        end
-      end
-      """
+    When I successfully run `rails generate model user email:string name:string`
+    And I successfully run `bundle exec rake db:migrate`
+  }
+end
+
+When /^I add an existing user$/ do
+  command = %q{rails runner "User.create!(email: 'a@b.com', name: 'foo')"}
+
+  steps %Q{
+    When I successfully run `#{command}`
+  }
+end
+
+When /existing user should have a remember token$/ do
+  command = 'rails runner "exit(1) unless User.first.remember_token"'
+
+  steps %Q{
+    When I successfully run `#{command}`
   }
 end
 

--- a/lib/clearance/token.rb
+++ b/lib/clearance/token.rb
@@ -1,0 +1,7 @@
+module Clearance
+  class Token
+    def self.new
+      SecureRandom.hex(20).encode('UTF-8')
+    end
+  end
+end

--- a/lib/clearance/user.rb
+++ b/lib/clearance/user.rb
@@ -1,5 +1,6 @@
 require 'digest/sha1'
 require 'email_validator'
+require 'clearance/token'
 
 module Clearance
   module User
@@ -102,11 +103,11 @@ module Clearance
     end
 
     def generate_confirmation_token
-      self.confirmation_token = SecureRandom.hex(20).encode('UTF-8')
+      self.confirmation_token = Clearance::Token.new
     end
 
     def generate_remember_token
-      self.remember_token = SecureRandom.hex(20).encode('UTF-8')
+      self.remember_token = Clearance::Token.new
     end
   end
 end

--- a/lib/generators/clearance/install/templates/db/migrate/add_clearance_to_users.rb
+++ b/lib/generators/clearance/install/templates/db/migrate/add_clearance_to_users.rb
@@ -9,6 +9,16 @@ class AddClearanceToUsers < ActiveRecord::Migration
 <% config[:new_indexes].values.each do |index| -%>
     <%= index %>
 <% end -%>
+
+    users = select_all('SELECT id FROM users WHERE remember_token IS NULL')
+
+    users.each do |user|
+      update <<-SQL
+        UPDATE users
+        SET remember_token = '#{Clearance::Token.new}'
+        WHERE id = '#{user['id']}'
+      SQL
+    end
   end
 
   def self.down

--- a/spec/clearance/token_spec.rb
+++ b/spec/clearance/token_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+describe Clearance::Token do
+  it 'is a random hex string' do
+    token = 'my_token'
+    SecureRandom.stubs(:hex).with(20).returns(token)
+
+    expect(Clearance::Token.new).to eq token
+  end
+end


### PR DESCRIPTION
The clearance migration to add clearance fields to an existing users table now
also ensures each user has a generated remember_token.

Closes #396
