### PR TITLE
Make travis retry on bundle install failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
   - "gem update --system"
 
 install:
-  - "bundle install"
+  - "travis_retry bundle install"
 
 before_script:
   - "bundle exec rake db:migrate"


### PR DESCRIPTION
Travis frequently has timeout problems when contacting rubygems. Travis
supplies the `travis_retry` command to help combat this. This will retry the
install up to 3 times.

This will not help when appraisal tries to install its missing dependencies.
Changes for that are probably best left to appraisal.
