### PR TITLE
Use available query string when redirecting

### DIFF
--- a/lib/clearance/authorization.rb
+++ b/lib/clearance/authorization.rb
@@ -52,7 +52,8 @@ module Clearance
 
     def return_to
       if return_to_url
-        URI.parse(return_to_url).path
+        uri = URI.parse(return_to_url)
+        "#{uri.path}?#{uri.query}".chomp('?')
       end
     end
 

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -43,7 +43,7 @@ describe Clearance::SessionsController do
   describe 'on POST to #create with good credentials and a session return url' do
     before do
       @user = create(:user)
-      @return_url = '/url_in_the_session'
+      @return_url = '/url_in_the_session?foo=bar'
       @request.session[:return_to] = @return_url
       post :create, session: { email: @user.email, password: @user.password }
     end


### PR DESCRIPTION
If the return_to url has a query string attached to it, we want to be sure we
are including it when clearance redirects.

URI::HTTP has the wonderful `request_uri` method that returns us the path and
query string together, but our session variable stores only
`fullpath` which URI parses as URI::Generic. That means we have to assemble
the path and query string ourselves.
