### PR TITLE
Preserve as much of the redirect URL as possible

### DIFF
--- a/lib/clearance/authorization.rb
+++ b/lib/clearance/authorization.rb
@@ -53,7 +53,7 @@ module Clearance
     def return_to
       if return_to_url
         uri = URI.parse(return_to_url)
-        "#{uri.path}?#{uri.query}".chomp('?')
+        uri.to_s.split("#{uri.host}:#{uri.port}".chomp(':')).last
       end
     end
 

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -41,15 +41,15 @@ describe Clearance::SessionsController do
   end
 
   describe 'on POST to #create with good credentials and a session return url' do
-    before do
-      @user = create(:user)
-      @return_url = '/url_in_the_session?foo=bar'
-      @request.session[:return_to] = @return_url
-      post :create, session: { email: @user.email, password: @user.password }
-    end
-
     it 'redirects to the return URL' do
-      should redirect_to(@return_url)
+      user = create(:user)
+      return_path = '/path_in_the_session?query=param#fragment'
+      return_url = 'http://example.com:1234/path_in_the_session?query=param#fragment'
+      request.session[:return_to] = return_url
+
+      post :create, session: { email: user.email, password: user.password }
+
+      response.should redirect_to(return_path)
     end
   end
 


### PR DESCRIPTION
Discard only the portion of the redirect_url _after_ the host and port, which 
will exclude the scheme, host, and port while preserving path, query, and
fragment.

```
http://foo.com:1234/posts?id=30&limit=5#time=1305298413
```

is transformed to

```
/posts?id=30&limit=5#time=1305298413
```
