### PR TITLE
Allow easy overriding of clearance controllers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 Thank you to all the [contributors](https://github.com/thoughtbot/clearance/graphs/contributors)!
 
+New on MASTER
+* Overriding clearance controllers is now simpler. The congiuration options
+  `users_controller`, `sessions_controller`, and `passwords_controller` can be
+  changed to point to the controller of your choosing.
+
 New for 1.3.0 (March 14, 2014)
 * Installing Clearance with an existing User model will now create a migration
   that includes adding remember tokens to all existing user records.

--- a/README.md
+++ b/README.md
@@ -64,10 +64,13 @@ Clearance.configure do |config|
   config.httponly = false
   config.mailer_sender = 'reply@example.com'
   config.password_strategy = Clearance::PasswordStrategies::BCrypt
+  config.passwords_controller = 'clearance/passwords'
   config.redirect_url = '/'
   config.secure_cookie = false
+  config.sessions_controller = 'clearance/sessions'
   config.sign_in_guards = []
   config.user_model = User
+  config.users_controller = 'clearance/users'
 end
 ```
 
@@ -174,7 +177,15 @@ class SessionsController < Clearance::SessionsController
 class UsersController < Clearance::UsersController
 ```
 
-Then, override public methods:
+In your configuration, change the applicable controllers like so:
+
+```ruby
+Clearance.configure do |config|
+  config.users_controller :users # default it 'clearance/users'
+end
+```
+
+To tweak default behavior, you can override these actions:
 
     passwords#create
     passwords#edit
@@ -186,7 +197,7 @@ Then, override public methods:
     users#create
     users#new
 
-Or, override private methods:
+Or, override the supporting private methods:
 
     passwords#find_user_by_id_and_confirmation_token
     passwords#find_user_for_create

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,24 +1,28 @@
 Rails.application.routes.draw do
+  users_controller = Clearance.configuration.users_controller
+  passwords_controller = Clearance.configuration.passwords_controller
+  sessions_controller = Clearance.configuration.sessions_controller
+
   resources :passwords,
-    controller: 'clearance/passwords',
+    controller: passwords_controller,
     only: [:create, :new]
 
   resource :session,
-    controller: 'clearance/sessions',
+    controller: sessions_controller,
     only: [:create]
 
   resources :users,
-    controller: 'clearance/users',
+    controller: users_controller,
     only: Clearance.configuration.user_actions do
       resource :password,
-        controller: 'clearance/passwords',
+        controller: passwords_controller,
         only: [:create, :edit, :update]
     end
 
-  get '/sign_in' => 'clearance/sessions#new', as: 'sign_in'
-  delete '/sign_out' => 'clearance/sessions#destroy', as: 'sign_out'
+  get '/sign_in' => "#{sessions_controller}#new", as: 'sign_in'
+  delete '/sign_out' => "#{sessions_controller}#destroy", as: 'sign_out'
 
   if Clearance.configuration.allow_sign_up?
-    get '/sign_up' => 'clearance/users#new', as: 'sign_up'
+    get '/sign_up' => "#{users_controller}#new", as: 'sign_up'
   end
 end

--- a/lib/clearance/configuration.rb
+++ b/lib/clearance/configuration.rb
@@ -9,10 +9,13 @@ module Clearance
       :httponly,
       :mailer_sender,
       :password_strategy,
+      :passwords_controller,
       :redirect_url,
       :secure_cookie,
+      :sessions_controller,
       :sign_in_guards,
-      :user_model
+      :user_model,
+      :users_controller
 
     def initialize
       @allow_sign_up = true
@@ -20,9 +23,12 @@ module Clearance
       @cookie_path = '/'
       @httponly = false
       @mailer_sender = 'reply@example.com'
+      @passwords_controller = 'clearance/passwords'
       @redirect_url = '/'
       @secure_cookie = false
+      @sessions_controller = 'clearance/sessions'
       @sign_in_guards = []
+      @users_controller = 'clearance/users'
     end
 
     def user_model

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -151,4 +151,44 @@ describe Clearance::Configuration do
       Clearance.configuration.user_id_parameter.should eq :custom_user_id
     end
   end
+
+  describe '#users_controller' do
+    it 'defaults to clearance/users' do
+      expect(configuration.users_controller).to eq 'clearance/users'
+    end
+
+    it 'can be overriden' do
+      controller = 'people'
+      Clearance.configure { |config| config.users_controller = controller }
+      expect(configuration.users_controller).to eq controller
+    end
+  end
+
+  describe '#sessions_controller' do
+    it 'defaults to clearance/sessions' do
+      expect(configuration.sessions_controller).to eq 'clearance/sessions'
+    end
+
+    it 'can be overriden' do
+      controller = 'admin/sessions'
+      Clearance.configure { |config| config.sessions_controller = controller }
+      expect(configuration.sessions_controller).to eq controller
+    end
+  end
+
+  describe '#passwords_controller' do
+    it 'defaults to clearance/passwords' do
+      expect(configuration.passwords_controller).to eq 'clearance/passwords'
+    end
+
+    it 'can be overriden' do
+      controller = 'admin/passwords'
+      Clearance.configure { |config| config.passwords_controller = controller }
+      expect(configuration.passwords_controller).to eq controller
+    end
+  end
+
+  def configuration
+    Clearance.configuration
+  end
 end

--- a/spec/routing/overridden_routes_spec.rb
+++ b/spec/routing/overridden_routes_spec.rb
@@ -1,0 +1,71 @@
+require 'spec_helper'
+
+describe 'clearance route overrides' do
+  around do |example|
+    configure_overridden_routes
+
+    example.run
+
+    restore_default_config
+  end
+
+  it 'overrides the users routes' do
+    expect(get: 'sign_up').to route_to("#{users_controller}#new")
+    expect(post: 'users').to route_to("#{users_controller}#create")
+  end
+
+  it 'overrides the sessions routes' do
+    expect(post: 'session').to route_to("#{sessions_controller}#create")
+    expect(get: 'sign_in').to route_to("#{sessions_controller}#new")
+    expect(delete: 'sign_out').to route_to("#{sessions_controller}#destroy")
+  end
+
+  it 'overrides the passwords routes' do
+    expect(get: 'passwords/new').to route_to("#{passwords_controller}#new")
+    expect(post: 'passwords').to route_to("#{passwords_controller}#create")
+
+    expect(get: 'users/1/password/edit').to route_to(
+      controller: passwords_controller,
+      action: 'edit',
+      user_id: '1'
+    )
+
+    expect(put: 'users/1/password').to route_to(
+      controller: passwords_controller,
+      action: 'update',
+      user_id: '1'
+    )
+
+    expect(post: 'users/1/password').to route_to(
+      controller: passwords_controller,
+      action: 'create',
+      user_id: '1'
+    )
+  end
+
+  def configure_overridden_routes
+    Clearance.configure do |config|
+      config.users_controller = users_controller
+      config.sessions_controller = sessions_controller
+      config.passwords_controller = passwords_controller
+    end
+
+    Rails.application.reload_routes!
+  end
+
+  def users_controller
+    'people'
+  end
+
+  def sessions_controller
+    'admin_sessions'
+  end
+
+  def passwords_controller
+    'admin_passwords'
+  end
+
+  class PeopleController < Clearance::UsersController; end
+  class AdminSessionsController < Clearance::SessionsController; end
+  class AdminPasswordsController < Clearance::PasswordsController; end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,4 +29,5 @@ end
 def restore_default_config
   Clearance.configuration = nil
   Clearance.configure {}
+  Rails.application.reload_routes!
 end


### PR DESCRIPTION
This is particularly useful for overriding the controller used in the sign_in,
sign_up, and sign_out routes. Rails 4 no longer allows overriding named routes
(an exception is raised), so having `sign_in` use your customized controller
(even when it was named `users`) required adding an unnamed (`as: nil`) route
that matched the same path and went to a different controller.

This difficulty is not a problem for resourceful routes. That is, adding your
own `resoures :passwords` to your routes file will override the routes as
expected. However, configuration was added for all controllers for the sake of
consistency and because it allows the user to change the controller without
having to know which actions the resources need to have available for
Clearance.
