### PR TITLE
Introduce Clearance::UsersConteroller#user_params

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ Or, override private methods:
     users#flash_failure_after_create
     users#url_after_create
     users#user_from_params
+    users#user_params
 
 All of these controller methods redirect to `'/'` by default:
 

--- a/app/controllers/clearance/users_controller.rb
+++ b/app/controllers/clearance/users_controller.rb
@@ -29,7 +29,6 @@ class Clearance::UsersController < Clearance::BaseController
   end
 
   def user_from_params
-    user_params = params[:user] || Hash.new
     email = user_params.delete(:email)
     password = user_params.delete(:password)
 
@@ -37,5 +36,9 @@ class Clearance::UsersController < Clearance::BaseController
       user.email = email
       user.password = password
     end
+  end
+
+  def user_params
+    params[:user] || Hash.new
   end
 end


### PR DESCRIPTION
This makes it easier to overwrite `user_params` when needing to provide extra
fields during signup.

For example, with `strong_parameter`:

``` ruby
class UsersController < Clearance::UsersController
  private

  def user_params
    params.require(:user).permit(:email, :password, :first_name, :last_name)
  end
end
```
