### PR TITLE
Upgrade to Appraisal 1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,17 +4,18 @@ language:
 rvm:
   - 1.9.3
   - 2.0.0
-  - 2.1.0
-
-before_install:
-  - "sudo apt-get install ca-certificates"
-  - "gem update --system"
+  - 2.1.1
 
 install:
   - "travis_retry bundle install"
+  - "bundle exec appraisal generate"
+  - "travis_retry bundle exec appraisal install"
 
 before_script:
   - "bundle exec rake db:migrate"
+
+script:
+  - "bundle exec appraisal rake"
 
 branches:
   only:

--- a/Appraisals
+++ b/Appraisals
@@ -9,13 +9,13 @@ end
 
 appraise 'rails4.0' do
   gem 'jbuilder', '~> 1.2'
-  gem 'rails', '~> 4.0.3'
+  gem 'rails', '~> 4.0.4'
   gem 'sdoc'
 end
 
 appraise 'rails4.1' do
   gem 'jbuilder', '~> 2.0'
-  gem 'rails', '~> 4.1.0.rc1'
+  gem 'rails', '~> 4.1.0'
   gem 'sdoc'
   gem 'spring'
 end

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,12 @@
 We love pull requests. Here's a quick guide:
 
-1. Fork the repo.
+1. Fork the repo and `bundle install`
 
 2. Set up Appraisal, which helps us test against multiple Rails versions:
-   `rake appraisal:install`.
+   `bundle exec appraisal install`
 
 3. Run the tests. We only take pull requests with passing tests, and it's great
-   to know that you have a clean slate: `rake`
+   to know that you have a clean slate: `bundle exec appraisal rake`
 
 4. Add a test for your change. Only refactoring and documentation changes
    require no new tests. If you are adding functionality or fixing a

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'appraisal', '~> 0.5'
+gem 'appraisal', '~> 1.0'
 gem 'aruba', '~> 0.5'
 gem 'bourne', '~> 1.4'
 gem 'bundler', '~> 1.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,9 +33,10 @@ GEM
       multi_json (~> 1.3)
       thread_safe (~> 0.1)
       tzinfo (~> 0.3.37)
-    appraisal (0.5.2)
+    appraisal (1.0.0)
       bundler
       rake
+      thor (>= 0.14.0)
     arel (4.0.1)
     aruba (0.5.4)
       childprocess (>= 0.3.6)
@@ -111,7 +112,7 @@ GEM
       activesupport (= 4.0.2)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
-    rake (10.1.1)
+    rake (10.2.2)
     rspec-core (2.14.7)
     rspec-expectations (2.14.4)
       diff-lcs (>= 1.1.3, < 2.0)
@@ -159,7 +160,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  appraisal (~> 0.5)
+  appraisal (~> 1.0)
   aruba (~> 0.5)
   bourne (~> 1.4)
   bundler (~> 1.3)

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,4 @@
 # encoding: utf-8
-
 require 'rubygems'
 require 'bundler/setup'
 require 'bundler/gem_tasks'
@@ -7,22 +6,19 @@ require 'bundler/gem_tasks'
 require 'rake'
 require 'cucumber/rake/task'
 require 'rspec/core/rake_task'
-require 'appraisal'
-
 require 'clearance/testing/application'
-Clearance::Testing::Application.load_tasks
 
 desc 'Default'
 task :default => [:all]
 
-desc 'Test the engine under all supported Rails versions'
-task :all => ['appraisal:install'] do |t|
-  exec 'rake appraisal spec cucumber'
-end
+desc 'Run the specs and cucumber featrues'
+task :all => [:spec, :cucumber]
 
-RSpec::Core::RakeTask.new(:spec)
+Clearance::Testing::Application.load_tasks
 
 Cucumber::Rake::Task.new(:cucumber) do |t|
   t.fork = false
   t.cucumber_opts = ['--format', (ENV['CUCUMBER_FORMAT'] || 'progress')]
 end
+
+RSpec::Core::RakeTask.new(:spec)


### PR DESCRIPTION
The default `rake` task is now the non-appraisal version, which runs both the
specs and features.  To run appraisals, use the appraisal CLI:
`appraisal rake`.

Updated travis config to use appraisal CLI. Updated rails 4.x dependencies to
latest versions.
