### PR TITLE
Use a secure session cookie for new installs

### DIFF
--- a/lib/clearance/authentication.rb
+++ b/lib/clearance/authentication.rb
@@ -21,6 +21,16 @@ module Clearance
     end
 
     def current_user
+      if !request.ssl? && Clearance.configuration.secure_cookie
+        raise <<-ERROR.strip_heredoc
+          Clearance has `secure_cookie` enabled in this environment but
+          `current_user` was just accessed during a non-SSL request. Assuming
+          this is a live environment, you probably want to set `force_ssl` to
+          true in your environment configuration or otherwise force HTTPS
+          connections.
+        ERROR
+      end
+
       clearance_session.current_user
     end
 

--- a/lib/clearance/configuration.rb
+++ b/lib/clearance/configuration.rb
@@ -21,7 +21,6 @@ module Clearance
       @httponly = false
       @mailer_sender = 'reply@example.com'
       @redirect_url = '/'
-      @secure_cookie = false
       @sign_in_guards = []
     end
 
@@ -31,6 +30,22 @@ module Clearance
 
     def allow_sign_up?
       @allow_sign_up
+    end
+
+    def secure_cookie
+      if @secure_cookie.nil?
+        warn <<-WARNING.strip_heredoc
+
+          Clearance.configuration.secure_cookie is not set and is defaulting to
+          false. This subjects your users to session hijacking. We reccomend
+          this be set to 'true' in any live environment and explicitly set to
+          false in development and test if necessary.
+        WARNING
+
+        @secure_cookie = false
+      end
+
+      @secure_cookie
     end
 
     def  user_actions

--- a/lib/generators/clearance/install/templates/clearance.rb
+++ b/lib/generators/clearance/install/templates/clearance.rb
@@ -1,3 +1,7 @@
 Clearance.configure do |config|
   config.mailer_sender = 'reply@example.com'
+
+  unless Rails.env.development? || Rails.env.test?
+    config.secure_cookie = true
+  end
 end

--- a/spec/clearance/authentication_spec.rb
+++ b/spec/clearance/authentication_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+describe Clearance::Authorization do
+  class DummyController < ActionController::Base
+    DummyRequest = Struct.new(:ssl?)
+    include Clearance::Authentication
+
+    def request
+      DummyRequest.new(false)
+    end
+  end
+
+  describe '#current_user' do
+    context 'non SSL request with secure_cookie enabled' do
+      it 'raises an error' do
+        Clearance.stubs(configuration: configuration)
+        controller = DummyController.new
+
+        expect { controller.current_user }.
+          to raise_error(RuntimeError, /secure_cookie/)
+      end
+    end
+  end
+
+  def configuration
+    stub(secure_cookie: true)
+  end
+end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -29,25 +29,32 @@ describe Clearance::Configuration do
   end
 
   context 'when secure_cookie is set to true' do
-    before do
+    it 'returns true' do
       Clearance.configure do |config|
         config.secure_cookie = true
       end
-    end
 
-    it 'returns true' do
       expect(Clearance.configuration.secure_cookie).to be_true
     end
   end
 
   context 'when secure_cookie is not specified' do
-    before do
-      Clearance.configure do |config|
+    it 'defaults to false' do
+      Clearance.configuration = Clearance::Configuration.new
+
+      silence_warnings do
+        expect(Clearance.configuration.secure_cookie).to be_false
       end
     end
 
-    it 'defaults to false' do
-      expect(Clearance.configuration.secure_cookie).to be_false
+    it 'warns when accessed if secure_cookie is nil' do
+      config = Clearance::Configuration.new
+      config.stubs(:warn)
+      Clearance.configuration = config
+
+      Clearance.configuration.secure_cookie
+
+      expect(config).to have_received(:warn)
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,6 +24,10 @@ RSpec.configure do |config|
   config.include FactoryGirl::Syntax::Methods
   config.mock_with :mocha
   config.use_transactional_fixtures = true
+
+  config.before(:each) do
+    Clearance.configuration.secure_cookie = false
+  end
 end
 
 def restore_default_config


### PR DESCRIPTION
Turning `secure_cookie` on has the effect of making the cookie HTTPS-only, and
thus not susceptible to session hijacking. For security, this should be the
default in environments other than development and test.

The default initializer has been updated to reflect this. In Clearance 2.0,
this may become the default behavior in Clearance internals and thus no longer
depend on the initializer being present and containing the proper setting.
