### PR TITLE
Use double quotes for HTML attributes

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,7 +5,7 @@
   <%= csrf_meta_tag %>
 </head>
 <body>
-  <div id='header'>
+  <div id="header">
     <% if signed_in? -%>
       <%= link_to t('.sign_out'), sign_out_path, :method => :delete %>
     <% else -%>
@@ -13,9 +13,9 @@
     <% end -%>
   </div>
 
-  <div id='flash'>
+  <div id="flash">
     <% flash.each do |key, value| -%>
-      <div id='flash_<%= key %>'><%=h value %></div>
+      <div id="flash_<%= key %>"><%=h value %></div>
     <% end %>
   </div>
 

--- a/app/views/passwords/edit.html.erb
+++ b/app/views/passwords/edit.html.erb
@@ -1,4 +1,4 @@
-<div id='clearance' class='password-reset'>
+<div id="clearance" class="password-reset">
   <h2><%= t '.title' %></h2>
 
   <p><%= t '.description' %></p>
@@ -6,12 +6,12 @@
   <%= form_for :password_reset,
         :url => user_password_path(@user, :token => @user.confirmation_token),
         :html => { :method => :put } do |form| %>
-    <div class='password-field'>
+    <div class="password-field">
       <%= form.label :password %>
       <%= form.password_field :password %>
     </div>
 
-    <div class='submit-field'>
+    <div class="submit-field">
       <%= form.submit %>
     </div>
   <% end %>

--- a/app/views/passwords/new.html.erb
+++ b/app/views/passwords/new.html.erb
@@ -1,15 +1,15 @@
-<div id='clearance' class='password-reset'>
+<div id="clearance" class="password-reset">
   <h2><%= t '.title' %></h2>
 
   <p><%= t '.description' %></p>
 
   <%= form_for :password, :url => passwords_path do |form| %>
-    <div class='text-field'>
+    <div class="text-field">
       <%= form.label :email %>
       <%= form.text_field :email, :type => 'email' %>
     </div>
 
-    <div class='submit-field'>
+    <div class="submit-field">
       <%= form.submit %>
     </div>
   <% end %>

--- a/app/views/sessions/_form.html.erb
+++ b/app/views/sessions/_form.html.erb
@@ -1,19 +1,19 @@
 <%= form_for :session, :url => session_path do |form| %>
-  <div class='text-field'>
+  <div class="text-field">
     <%= form.label :email %>
     <%= form.text_field :email, :type => 'email' %>
   </div>
 
-  <div class='password-field'>
+  <div class="password-field">
     <%= form.label :password %>
     <%= form.password_field :password %>
   </div>
 
-  <div class='submit-field'>
+  <div class="submit-field">
     <%= form.submit %>
   </div>
 
-  <div class='other-links'>
+  <div class="other-links">
     <% if Clearance.configuration.allow_sign_up? %>
       <%= link_to t('.sign_up'), sign_up_path %>
     <% end %>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,4 +1,4 @@
-<div id='clearance' class='sign-in'>
+<div id="clearance" class="sign-in">
   <h2><%= t '.title' %></h2>
 
   <%= render :partial => '/sessions/form' %>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -1,9 +1,9 @@
-<div class='text-field'>
+<div class="text-field">
   <%= form.label :email %>
   <%= form.text_field :email, :type => 'email' %>
 </div>
 
-<div class='password-field'>
+<div class="password-field">
   <%= form.label :password %>
   <%= form.password_field :password %>
 </div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,14 +1,14 @@
-<div id='clearance' class='sign-up'>
+<div id="clearance" class="sign-up">
   <h2><%= t('.title') %></h2>
 
   <%= form_for @user do |form| %>
     <%= render :partial => '/users/form', :object => form %>
 
-    <div class='submit-field'>
+    <div class="submit-field">
       <%= form.submit %>
     </div>
 
-    <div class='other-links'>
+    <div class="other-links">
       <%= link_to t('.sign_in'), sign_in_path %>
     </div>
   <% end %>


### PR DESCRIPTION
Our style guide says to prefer double quotes for HTML and ERb
attributes. Apply this consistently throughout this repo.
