### PR TITLE
Remove support for Rails 3.2

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -1,12 +1,6 @@
 # These are the various versions of rails we want to test against.
 # The non-rails gems (jbuilder, sdoc, etc) are dependencies introduced
 # in the default rails gemfiles used in the clearance features.
-appraise 'rails3.2' do
-  gem 'jbuilder', '~> 1.2'
-  gem 'rails', '~> 3.2.17'
-  gem 'sdoc'
-end
-
 appraise 'rails4.0' do
   gem 'jbuilder', '~> 1.2'
   gem 'rails', '~> 4.0.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,10 @@
 PATH
   remote: .
   specs:
-    clearance (1.3.0)
+    clearance (2.0.0.alpha)
       bcrypt
       email_validator (~> 1.4)
-      rails (>= 3.1)
+      rails (>= 4.0)
 
 GEM
   remote: https://rubygems.org/

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@ New for 2.0.0.alpha
 * Clearance routes can now be turned off via configuration (`routes = false`).
   The `clearance:routes` turns off the routes and copies the default routes to
   the host application's routes file for customization.
+* Rails 3.2 support dropped.
 
 New for 1.3.0 (March 14, 2014)
 * Installing Clearance with an existing User model will now create a migration

--- a/README.md
+++ b/README.md
@@ -18,8 +18,7 @@ Read [CONTRIBUTING.md](/CONTRIBUTING.md) to contribute.
 Install
 -------
 
-Clearance is a Rails engine tested against Rails `>= 3.2` and Ruby `>= 1.9.3`.
-It works with Rails 4 and Ruby 2.
+Clearance is a Rails engine tested against Rails `>= 4.0` and Ruby `>= 1.9.3`.
 
 Include the gem in your Gemfile:
 
@@ -43,12 +42,6 @@ The generator:
   columns
 
 Then, follow the instructions output from the generator.
-
-Use Clearance [0.8.8](https://github.com/thoughtbot/clearance/tree/v0.8.8) for
-Rails 2 apps.
-
-Use Clearance [0.16.3](http://rubygems.org/gems/clearance/versions/0.16.3) for
-Ruby 1.8.7 apps.
 
 Configure
 ---------

--- a/clearance.gemspec
+++ b/clearance.gemspec
@@ -5,7 +5,7 @@ require 'date'
 Gem::Specification.new do |s|
   s.add_dependency 'bcrypt'
   s.add_dependency 'email_validator', '~> 1.4'
-  s.add_dependency 'rails', '>= 3.1'
+  s.add_dependency 'rails', '>= 4.0'
   s.authors = [
     'Dan Croak',
     'Eugene Bolshakov',
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
   s.name = %q{clearance}
   s.rdoc_options = ['--charset=UTF-8']
   s.require_paths = ['lib']
-  s.required_ruby_version = Gem::Requirement.new('>= 1.9.2')
+  s.required_ruby_version = Gem::Requirement.new('>= 1.9.3')
   s.summary = 'Rails authentication & authorization with email & password.'
   s.test_files = `git ls-files -- {features,spec}/*`.split("\n")
   s.version = Clearance::VERSION


### PR DESCRIPTION
The maintenance policy for rails is to support the last two release series'.
This would be 4.1.x and 4.0.x at this point.

Clearance 2.0 drops support for 3.2
