### PR TITLE
Remove unnecessary autoload call from PasswordStrategies module.

### DIFF
--- a/lib/clearance/password_strategies.rb
+++ b/lib/clearance/password_strategies.rb
@@ -4,7 +4,6 @@ module Clearance
     autoload :BCryptMigrationFromSHA1,
       'clearance/password_strategies/bcrypt_migration_from_sha1'
     autoload :Blowfish, 'clearance/password_strategies/blowfish'
-    autoload :Fake, 'clearance/password_strategies/fake'
     autoload :SHA1, 'clearance/password_strategies/sha1'
   end
 end


### PR DESCRIPTION
Hello, thoughbot! 

I think this is a leftover from 6dbfc12a417165b6ad0270df7b863d0b540a313a, since the `Clearance::PasswordStrategies::Fake` module doesn't exist anymore. Considering this is a bosonic diff, I didn't add any tests but I ran the suite after this change and all tests passed.
