### PR TITLE
Replace sign out links with sign out buttons.

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ helpers. For example:
 ```haml
 - if signed_in?
   = current_user.email
-  = link_to 'Sign out', sign_out_path, method: :delete
+  = button_to 'Sign out', sign_out_path, method: :delete
 - else
   = link_to 'Sign in', sign_in_path
 ```

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,7 +7,7 @@
 <body>
   <div id="header">
     <% if signed_in? -%>
-      <%= link_to t('.sign_out'), sign_out_path, :method => :delete %>
+      <%= button_to t('.sign_out'), sign_out_path, :method => :delete %>
     <% else -%>
       <%= link_to t('.sign_in'), sign_in_path %>
     <% end -%>

--- a/lib/generators/clearance/install/templates/README
+++ b/lib/generators/clearance/install/templates/README
@@ -14,7 +14,7 @@ Next steps:
 
     <% if signed_in? %>
       Signed in as: <%= current_user.email %>
-      <%= link_to 'Sign out', sign_out_path, method: :delete %>
+      <%= button_to 'Sign out', sign_out_path, method: :delete %>
     <% else %>
       <%= link_to 'Sign in', sign_in_path %>
     <% end %>

--- a/lib/generators/clearance/specs/templates/support/features/clearance_helpers.rb
+++ b/lib/generators/clearance/specs/templates/support/features/clearance_helpers.rb
@@ -23,11 +23,11 @@ module Features
 
     def user_should_be_signed_in
       visit root_path
-      page.should have_content I18n.t('layouts.application.sign_out')
+      page.should have_button I18n.t('layouts.application.sign_out')
     end
 
     def sign_out
-      click_link I18n.t('layouts.application.sign_out')
+      click_button I18n.t('layouts.application.sign_out')
     end
 
     def user_should_be_signed_out


### PR DESCRIPTION
Using `button_to` instead of `link_to` for DELETE requests removes an unnecessary dependency on JavaScript. I've made this change in projects using clearance a couple of times in the last few months, so I wanted to push the change up stream.
