### PR TITLE
Use request.original_fullpath instead of request.fullpath in store_location

### DIFF
--- a/lib/clearance/authorization.rb
+++ b/lib/clearance/authorization.rb
@@ -41,7 +41,7 @@ module Clearance
 
     def store_location
       if request.get?
-        session[:return_to] = request.fullpath
+        session[:return_to] = request.original_fullpath
       end
     end
 


### PR DESCRIPTION
original_fullpath works better than fullpath here, because fullpath doesn't play nice with mounted engines.

For example, with rails_admin, request.fullpath is "/admin/" but request.original_fullpath is "/admin".
