### PR TITLE
Backport setting to disable all routes from 2.0

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,24 +1,26 @@
-Rails.application.routes.draw do
-  resources :passwords,
-    controller: 'clearance/passwords',
-    only: [:create, :new]
+if Clearance.configuration.routes_enabled?
+  Rails.application.routes.draw do
+    resources :passwords,
+      controller: 'clearance/passwords',
+      only: [:create, :new]
 
-  resource :session,
-    controller: 'clearance/sessions',
-    only: [:create]
+    resource :session,
+      controller: 'clearance/sessions',
+      only: [:create]
 
-  resources :users,
-    controller: 'clearance/users',
-    only: Clearance.configuration.user_actions do
-      resource :password,
-        controller: 'clearance/passwords',
-        only: [:create, :edit, :update]
+    resources :users,
+      controller: 'clearance/users',
+      only: Clearance.configuration.user_actions do
+        resource :password,
+          controller: 'clearance/passwords',
+          only: [:create, :edit, :update]
+      end
+
+    get '/sign_in' => 'clearance/sessions#new', as: 'sign_in'
+    delete '/sign_out' => 'clearance/sessions#destroy', as: 'sign_out'
+
+    if Clearance.configuration.allow_sign_up?
+      get '/sign_up' => 'clearance/users#new', as: 'sign_up'
     end
-
-  get '/sign_in' => 'clearance/sessions#new', as: 'sign_in'
-  delete '/sign_out' => 'clearance/sessions#destroy', as: 'sign_out'
-
-  if Clearance.configuration.allow_sign_up?
-    get '/sign_up' => 'clearance/users#new', as: 'sign_up'
   end
 end

--- a/lib/clearance/configuration.rb
+++ b/lib/clearance/configuration.rb
@@ -1,6 +1,6 @@
 module Clearance
   class Configuration
-    attr_writer :allow_sign_up
+    attr_writer :allow_sign_up, :routes
 
     attr_accessor \
       :cookie_domain,
@@ -21,6 +21,7 @@ module Clearance
       @httponly = false
       @mailer_sender = 'reply@example.com'
       @redirect_url = '/'
+      @routes = true
       @secure_cookie = false
       @sign_in_guards = []
     end
@@ -43,6 +44,10 @@ module Clearance
 
     def user_id_parameter
       "#{user_model.model_name.singular}_id".to_sym
+    end
+
+    def routes_enabled?
+      @routes
     end
   end
 

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -113,7 +113,7 @@ describe Clearance::Configuration do
     end
   end
 
-  describe '#sign_up?' do
+  describe '#allow_sign_up?' do
     context 'when allow_sign_up is configured to false' do
       it 'returns false' do
         Clearance.configure { |config| config.allow_sign_up = false }
@@ -149,6 +149,17 @@ describe Clearance::Configuration do
       Clearance.configure { |config| config.user_model = CustomUser }
 
       Clearance.configuration.user_id_parameter.should eq :custom_user_id
+    end
+  end
+
+  describe '#routes_enabled?' do
+    it 'is true by default' do
+      Clearance.configuration.routes_enabled?.should be true
+    end
+
+    it 'is false when routes are set to false' do
+      Clearance.configure { |config| config.routes = false }
+      Clearance.configuration.routes_enabled?.should be false
     end
   end
 end

--- a/spec/routing/clearance_routes_spec.rb
+++ b/spec/routing/clearance_routes_spec.rb
@@ -1,16 +1,30 @@
 require 'spec_helper'
 
 describe 'routes for Clearance' do
-  context 'signup disabled' do
-    before(:all) do
-      Clearance.configure do |config|
-        config.allow_sign_up = false
-      end
-
+  context 'routes disabled' do
+    around do |example|
+      Clearance.configure { |config| config.routes = false }
+      Rails.application.reload_routes!
+      example.run
+      Clearance.configuration = Clearance::Configuration.new
       Rails.application.reload_routes!
     end
 
-    after :all do
+    it 'does not draw any routes' do
+      expect(get: 'sign_up').not_to be_routable
+      expect(get: 'sign_in').not_to be_routable
+      expect(get: 'passwords/new').not_to be_routable
+      expect(post: 'sessions').not_to be_routable
+      expect(post: 'passwords').not_to be_routable
+      expect(post: 'users').not_to be_routable
+    end
+  end
+
+  context 'signup disabled' do
+    around do |example|
+      Clearance.configure { |config| config.allow_sign_up = false }
+      Rails.application.reload_routes!
+      example.run
       Clearance.configuration = Clearance::Configuration.new
       Rails.application.reload_routes!
     end


### PR DESCRIPTION
From https://github.com/thoughtbot/clearance/commit/02ba479975fb1457fd5f2e5bc94fe2d441c72fd2

This new configuration option appears to be backwards compatible.
