### PR TITLE
Fix bcrypt hash error if `encrypted_password` is nil

### DIFF
--- a/lib/clearance/password_strategies/bcrypt.rb
+++ b/lib/clearance/password_strategies/bcrypt.rb
@@ -6,7 +6,9 @@ module Clearance
       extend ActiveSupport::Concern
 
       def authenticated?(password)
-        ::BCrypt::Password.new(encrypted_password) == password
+        if encrypted_password.present?
+          ::BCrypt::Password.new(encrypted_password) == password
+        end
       end
 
       def password=(new_password)

--- a/spec/models/bcrypt_spec.rb
+++ b/spec/models/bcrypt_spec.rb
@@ -41,14 +41,25 @@ describe Clearance::PasswordStrategies::BCrypt do
   end
 
   describe '#authenticated?' do
-    let(:password) { 'password' }
 
     before do
       subject.password = password
     end
 
-    it 'is authenticated with BCrypt' do
-      subject.should be_authenticated(password)
+    context 'given a password' do
+      let(:password) { 'password' }
+
+      it 'is authenticated with BCrypt' do
+        subject.should be_authenticated(password)
+      end
+    end
+
+    context 'given no password' do
+      let(:password) { nil }
+
+      it 'is not authenticated' do
+        subject.should_not be_authenticated(password)
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes the following error if a user attempts to authenticate to an account that doesn't have a password (for example, if it was created by omniauth):

```
BCrypt::Errors::InvalidHash - invalid hash:
  bcrypt (3.1.7) lib/bcrypt/password.rb:60:in `initialize'
  clearance (1.4.0) lib/clearance/password_strategies/bcrypt.rb:9:in `authenticated?'
  clearance (1.4.0) lib/clearance/user.rb:21:in `authenticate'
  clearance (1.4.0) lib/clearance/authentication.rb:18:in `authenticate'
```

Only this strategy is affected by this, the other strategies gracefully handle a nil `encrypted_password`.
