### PR TITLE
Routing constraints handle missing sessions data

### DIFF
--- a/lib/clearance/constraints/signed_in.rb
+++ b/lib/clearance/constraints/signed_in.rb
@@ -12,8 +12,12 @@ module Clearance
 
       private
 
+      def clearance_session
+        @request.env[:clearance]
+      end
+
       def current_user
-        @request.env[:clearance].current_user
+        clearance_session.current_user
       end
 
       def current_user_fulfills_additional_requirements?
@@ -21,7 +25,7 @@ module Clearance
       end
 
       def signed_in?
-        @request.env[:clearance].signed_in?
+        clearance_session.present? && clearance_session.signed_in?
       end
     end
   end

--- a/lib/clearance/constraints/signed_out.rb
+++ b/lib/clearance/constraints/signed_out.rb
@@ -2,7 +2,18 @@ module Clearance
   module Constraints
     class SignedOut
       def matches?(request)
-        request.env[:clearance].signed_out?
+        @request = request
+        missing_session? || clearance_session.signed_out?
+      end
+
+      private
+
+      def clearance_session
+        @request.env[:clearance]
+      end
+
+      def missing_session?
+        clearance_session.nil?
       end
     end
   end

--- a/spec/clearance/constraints/signed_in_spec.rb
+++ b/spec/clearance/constraints/signed_in_spec.rb
@@ -3,49 +3,56 @@ require 'spec_helper'
 describe Clearance::Constraints::SignedIn do
   it 'returns true when user is signed in' do
     user = create(:user)
-    signed_in_constraint = Clearance::Constraints::SignedIn.new
-    signed_in_constraint.matches?(request_with_remember_token(user.remember_token)).
-      should be_true
+    constraint = Clearance::Constraints::SignedIn.new
+    request = request_with_remember_token(user.remember_token)
+    expect(constraint.matches?(request)).to eq true
   end
 
   it 'returns false when user is not signed in' do
-    signed_in_constraint = Clearance::Constraints::SignedIn.new
-    signed_in_constraint.matches?(request_without_remember_token).should be_false
+    constraint = Clearance::Constraints::SignedIn.new
+    request = request_without_remember_token
+    expect(constraint.matches?(request)).to eq false
+  end
+
+  it 'returns false when clearance session data is not present' do
+    constraint = Clearance::Constraints::SignedIn.new
+    request = Rack::Request.new({})
+    expect(constraint.matches?(request)).to eq false
   end
 
   it 'yields a signed-in user to a provided block' do
     user = create(:user, email: 'before@example.com')
 
-    signed_in_constraint = Clearance::Constraints::SignedIn.new do |user|
-      user.update_attribute :email, 'after@example.com'
+    constraint = Clearance::Constraints::SignedIn.new do |signed_in_user|
+      signed_in_user.update_attribute :email, 'after@example.com'
     end
 
-    signed_in_constraint.matches?(request_with_remember_token(user.remember_token))
-    user.reload.email.should == 'after@example.com'
+    constraint.matches?(request_with_remember_token(user.remember_token))
+    expect(user.reload.email).to eq 'after@example.com'
   end
 
   it 'does not yield a user if they are not signed in' do
     user = create(:user, email: 'before@example.com')
 
-    signed_in_constraint = Clearance::Constraints::SignedIn.new do |user|
-      user.update_attribute :email, 'after@example.com'
+    constraint = Clearance::Constraints::SignedIn.new do |signed_in_user|
+      signed_in_user.update_attribute :email, 'after@example.com'
     end
 
-    signed_in_constraint.matches?(request_without_remember_token)
-    user.reload.email.should == 'before@example.com'
+    constraint.matches?(request_without_remember_token)
+    expect(user.reload.email).to eq 'before@example.com'
   end
 
   it 'matches if the user-provided block returns true' do
     user = create(:user)
-    signed_in_constraint = Clearance::Constraints::SignedIn.new { |user| true }
-    signed_in_constraint.matches?(request_with_remember_token(user.remember_token)).
-      should be_true
+    constraint = Clearance::Constraints::SignedIn.new { true }
+    request = request_with_remember_token(user.remember_token)
+    expect(constraint.matches?(request)).to eq true
   end
 
   it 'does not match if the user-provided block returns false' do
     user = create(:user)
-    signed_in_constraint = Clearance::Constraints::SignedIn.new { |user| false }
-    signed_in_constraint.matches?(request_with_remember_token(user.remember_token)).
-      should be_false
+    constraint = Clearance::Constraints::SignedIn.new { false }
+    request = request_with_remember_token(user.remember_token)
+    expect(constraint.matches?(request)).to eq false
   end
 end

--- a/spec/clearance/constraints/signed_out_spec.rb
+++ b/spec/clearance/constraints/signed_out_spec.rb
@@ -2,14 +2,21 @@ require 'spec_helper'
 
 describe Clearance::Constraints::SignedOut do
   it 'returns true when user is signed out' do
-    signed_out_constraint = Clearance::Constraints::SignedOut.new
-    signed_out_constraint.matches?(request_without_remember_token).should be_true
+    constraint = Clearance::Constraints::SignedOut.new
+    request = request_without_remember_token
+    expect(constraint.matches?(request)).to eq true
   end
 
   it 'returns false when user is not signed out' do
     user = create(:user)
-    signed_out_constraint = Clearance::Constraints::SignedOut.new
-    signed_out_constraint.matches?(request_with_remember_token(user.remember_token)).
-      should be_false
+    constraint = Clearance::Constraints::SignedOut.new
+    request = request_with_remember_token(user.remember_token)
+    expect(constraint.matches?(request)).to eq false
+  end
+
+  it 'returns true when clearance info is missing from request' do
+    constraint = Clearance::Constraints::SignedOut.new
+    request = Rack::Request.new({})
+    expect(constraint.matches?(request)).to eq true
   end
 end


### PR DESCRIPTION
Routing constraints should behave appropriately when
`request.env[:clearance]` is not set. That is, the SignedIn
constraint should not match while the SignedOut constraint
should.
