### PR TITLE
Don't raise `NoMethodError` in `sign_in_as` helper

### DIFF
--- a/lib/clearance/testing/helpers.rb
+++ b/lib/clearance/testing/helpers.rb
@@ -19,7 +19,7 @@ module Clearance
       end
 
       def sign_in_as(user)
-        @controller.sign_in user
+        @controller.send(:sign_in, user)
         user
       end
 

--- a/spec/clearance/testing/helpers_spec.rb
+++ b/spec/clearance/testing/helpers_spec.rb
@@ -9,6 +9,8 @@ describe Clearance::Testing::Helpers do
     end
 
     class Controller
+      protected
+
       def sign_in(user); end
     end
   end


### PR DESCRIPTION
I was overriding `sign_in` in a subclassed controller (ApplicationController was
public, but a subclass was used for all pages requiring authentication), and
experienced problems during testing where exceptions were being raised by
Clearance's testing helpers calling the protected method `#sign_in` on the
controller.

Changed the `sign_in_as` helper to use `Object#send`, which will not raise
`NoMethodError` if a controller's `#sign_in` method is protected, which as
a non-action controller method it should be.

Close #424.
