### PR TITLE
Error on mail to reset password url to path

### DIFF
--- a/app/views/clearance_mailer/change_password.html.erb
+++ b/app/views/clearance_mailer/change_password.html.erb
@@ -1,5 +1,5 @@
 <%= t('.opening') %>
 
-<%= edit_user_password_url(@user, :token => @user.confirmation_token.html_safe) %>
+<%= edit_user_password_path(@user, :token => @user.confirmation_token.html_safe) %>
 
 <%= t('.closing') %>


### PR DESCRIPTION
Missing host to link to! Please provide the :host parameter, set
default_url_options[:host], or set :only_path to true
