### PR TITLE
Remove configuration update made by generator

### DIFF
--- a/features/copy_routes_to_host_application.feature
+++ b/features/copy_routes_to_host_application.feature
@@ -6,5 +6,4 @@ Feature: copy routes to host application
    Scenario:
     When I successfully run `bundle exec rails generate clearance:install`
     And I successfully run `bundle exec rails generate clearance:routes`
-    Then the file "config/initializers/clearance.rb" should contain "config.routes = false"
-    And the file "config/routes.rb" should contain "get '/sign_in' => 'clearance/sessions#new', as: 'sign_in'"
+    Then the file "config/routes.rb" should contain "get '/sign_in' => 'clearance/sessions#new', as: 'sign_in'"

--- a/lib/generators/clearance/routes/routes_generator.rb
+++ b/lib/generators/clearance/routes/routes_generator.rb
@@ -5,14 +5,6 @@ module Clearance
     class RoutesGenerator < Rails::Generators::Base
       source_root File.expand_path('../templates', __FILE__)
 
-      def disable_clearance_routes_in_config
-        inject_into_file(
-          'config/initializers/clearance.rb',
-          '  config.routes = false\n',
-          after: /^Clearance\.configure do |config|\n/
-        )
-      end
-
       def inject_clearance_routes_into_application_routes
         route(clearance_routes)
       end

--- a/lib/generators/clearance/routes/templates/routes.rb
+++ b/lib/generators/clearance/routes/templates/routes.rb
@@ -1,4 +1,4 @@
-  resources :passwords, controller: 'clearance/passwords', only: [:create, :new]
+resources :passwords, controller: 'clearance/passwords', only: [:create, :new]
   resource :session, controller: 'clearance/sessions', only: [:create]
 
   resources :users, controller: 'clearance/users', only: [:create] do


### PR DESCRIPTION
This code doesn't work. It results in a mangled initializer. We can address
this in a future release if needed, but I  think it might be best for it to be
two separate steps anyway.

Also changed the indentation in the routes template. It looks off there but it
results in nicely formatted routes when inserted.
