### PR TITLE
Add PKCS5 password strategy.

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,7 @@ Clearance::PasswordStrategies::BCrypt
 Clearance::PasswordStrategies::BCryptMigrationFromSHA1
 Clearance::PasswordStrategies::Blowfish
 Clearance::PasswordStrategies::SHA1
+Clearance::PasswordStrategies::PKCS5
 ```
 
 The previous default password strategy was SHA1.
@@ -329,7 +330,8 @@ switch to BCrypt transparently, use
 [Clearance::PasswordStrategies::BCryptMigrationFromSHA1](/lib/clearance/password_strategies/bcrypt_migration_from_sha1.rb).
 
 The SHA1 and Blowfish password strategies require an additional `salt` column in
-the `users` table. Run this migration before switching to SHA or Blowfish:
+the `users` table. Run this migration before switching to SHA, Blowfish
+or PKCS5:
 
 ```ruby
 class AddSaltToUsers < ActiveRecord::Migration

--- a/lib/clearance/password_strategies.rb
+++ b/lib/clearance/password_strategies.rb
@@ -5,5 +5,6 @@ module Clearance
       'clearance/password_strategies/bcrypt_migration_from_sha1'
     autoload :Blowfish, 'clearance/password_strategies/blowfish'
     autoload :SHA1, 'clearance/password_strategies/sha1'
+    autoload :PKCS5, 'clearance/password_strategies/pkcs5'
   end
 end

--- a/lib/clearance/password_strategies/pkcs5.rb
+++ b/lib/clearance/password_strategies/pkcs5.rb
@@ -1,0 +1,52 @@
+module Clearance
+  module PasswordStrategies
+    module PKCS5
+      # Base64.encode64(OpenSSL::PKCS5.pbkdf2_hmac('yeah', OpenSSL::Random.random_bytes(16), 20000, 16, OpenSSL::Digest::SHA256.new))
+      require 'openssl'
+      require 'base64'
+
+      def authenticated?(password)
+        encrypted_password == encrypt(password)
+      end
+
+      def password=(new_password)
+        if new_password.present?
+          self.encrypted_password = encrypt(new_password)
+        end
+      end
+
+      protected
+      def encryption_provider
+        OpenSSL::PKCS5
+      end
+
+      def encrypt(string)
+        initialize_salt_if_neccessary
+        salt = Base64.decode64(self.salt)
+        cipher = encryption_provider.pbkdf2_hmac_sha1(string, salt, iterations, 16)
+        Base64.encode64(cipher).encode('utf-8')
+      end
+
+      def initialize_salt_if_neccessary
+        self.salt = generate_salt if self.salt.blank?
+      end
+
+      def generate_salt
+        Base64.encode64(OpenSSL::Random.random_bytes(16)).encode('utf-8')
+      end
+
+      def iterations
+        if test_environment?
+          1
+        else
+          20_000
+        end
+      end
+
+      def test_environment?
+        defined?(::Rails) && ::Rails.env.test?
+      end
+
+    end
+  end
+end

--- a/spec/models/pkcs5_spec.rb
+++ b/spec/models/pkcs5_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+
+describe Clearance::PasswordStrategies::PKCS5 do
+
+  subject do
+    fake_model_with_password_strategy(Clearance::PasswordStrategies::PKCS5)
+  end
+
+  describe '#password=' do
+
+    context 'when the password is set' do
+      let(:salt) { 'salt' }
+      let(:password) { 'password' }
+
+      before do
+        subject.salt = salt
+        subject.password = password
+      end
+
+      it 'encrypts the password using PKCS5' do
+        encrypted = Base64.decode64(subject.encrypted_password)
+        salt = Base64.decode64(subject.salt)
+        decode_cipher = OpenSSL::PKCS5.pbkdf2_hmac_sha1(password, salt, 1, 16)
+
+        expect(decode_cipher).to eq encrypted
+      end
+    end
+
+    context 'when the salt is not set' do
+      before do
+        subject.salt = nil
+        subject.password = 'whatever'
+      end
+
+      it 'should initialize the salt' do
+        expect(subject.salt).not_to be_nil
+      end
+
+      it 'should store the salt in plain-text' do
+        expect(subject.salt.encoding.name).to eq("UTF-8")
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is the first of two pull requests (hopefully).  If Blowfish is going away, PKCS5 is a good alternative from what I know.  It's designed for password encryption.  It still requires the salt column so hopefully that's not the goal of deprecating Blowfish (or possibly SHA1).

The appraisal steps from `CONTRIBUTING.md` and the complete test suite failed for me on master/v1.5.0 without my changes.  I'm not sure of the status of appraisal checks for pull requests.  Maybe I can take a look at the rspec and cucumber suite ...
