### PR TITLE
Blowfish encoding

### DIFF
--- a/lib/clearance/password_strategies/blowfish.rb
+++ b/lib/clearance/password_strategies/blowfish.rb
@@ -26,8 +26,8 @@ module Clearance
       def generate_hash(string)
         cipher = OpenSSL::Cipher::Cipher.new('bf-cbc').encrypt
         cipher.key = Digest::SHA256.digest(salt)
-        cipher.update(string) << cipher.final
-        Base64.encode64(string).encode('utf-8')
+        hash = cipher.update(string) << cipher.final
+        Base64.encode64(hash).encode('utf-8')
       end
 
       def initialize_salt_if_necessary

--- a/spec/models/blowfish_spec.rb
+++ b/spec/models/blowfish_spec.rb
@@ -23,7 +23,8 @@ describe Clearance::PasswordStrategies::Blowfish do
         cipher = OpenSSL::Cipher::Cipher.new('bf-cbc').encrypt
         cipher.key = Digest::SHA256.digest(salt)
         expected = cipher.update("--#{salt}--#{password}--") << cipher.final
-        expect(subject.encrypted_password).to eq expected
+        encrypted_password = Base64.decode64(subject.encrypted_password)
+        expect(encrypted_password).to eq expected
       end
     end
 


### PR DESCRIPTION
Ok.  I've (manually) tested this with sqlite3 and the mysql2 gem.  I believe this fixes #473.  Tests pass but that's just rspec against my test.

Cucumber suite seems broken.  I'd love to have some integration tests to regression password length because I believe that base64 encoding fixes this problem but might have a side effect on really long (10+ characters) passwords.  I can't find a side effect right now but cucumber beats manual testing.  :sob: 

If there is one, the user column `encrypted_password` would need to be changed to something more than 128.
