### PR TITLE
Remove call to user_params for new action in user controller

### DIFF
--- a/app/controllers/clearance/users_controller.rb
+++ b/app/controllers/clearance/users_controller.rb
@@ -4,6 +4,9 @@ class Clearance::UsersController < Clearance::BaseController
 
   def new
     @user = Clearance.configuration.user_model.new
+    if got_email?
+      @user.email = params[:user][:email]
+    end
     render template: 'users/new'
   end
 
@@ -22,6 +25,10 @@ class Clearance::UsersController < Clearance::BaseController
 
   def avoid_sign_in
     redirect_to Clearance.configuration.redirect_url
+  end
+
+  def got_email?
+    params[:user] && params[:user][:email]
   end
 
   def url_after_create


### PR DESCRIPTION
Calling `user_from_params` here takes away the possibility for users that
override the controller to override the `user_params` method with
`params.require(:user)`, which is a very common pattern for rails 4 and up
applications.

This also opens the door to remove the `Hash.new` call in the default
`user_params`, but I didn't want to go that far before understanding if
there is a good reason not to do this.
