### PR TITLE
Update mailer spec

### DIFF
--- a/app/mailers/clearance_mailer.rb
+++ b/app/mailers/clearance_mailer.rb
@@ -1,9 +1,14 @@
 class ClearanceMailer < ActionMailer::Base
   def change_password(user)
     @user = user
-    mail from: Clearance.configuration.mailer_sender, to: @user.email,
-      subject: I18n.t(:change_password,
-         scope: [:clearance, :models, :clearance_mailer],
-         default: 'Change your password')
+    mail(
+      from: Clearance.configuration.mailer_sender,
+      to: @user.email,
+      subject: I18n.t(
+        :change_password,
+        scope: [:clearance, :models, :clearance_mailer],
+        default: "Change your password"
+      )
+    )
   end
 end

--- a/app/views/clearance_mailer/change_password.html.erb
+++ b/app/views/clearance_mailer/change_password.html.erb
@@ -1,5 +1,5 @@
-<%= t('.opening') %>
+<%= t(".opening") %>
 
-<%= edit_user_password_url(@user, :token => @user.confirmation_token.html_safe) %>
+<%= edit_user_password_url(@user, token: @user.confirmation_token.html_safe) %>
 
-<%= t('.closing') %>
+<%= raw t(".closing") %>

--- a/config/locales/clearance.en.yml
+++ b/config/locales/clearance.en.yml
@@ -2,10 +2,10 @@
 en:
   clearance_mailer:
     change_password:
-      closing: If you didn't request this, ignore this email. Your password
-        has not been changed.
-      opening: 'Someone, hopefully you, requested we send you a link to change
-        your password:'
+      closing: If you didn't request this, ignore this email. Your password has
+        not been changed.
+      opening: "Someone, hopefully you, requested we send you a link to change
+        your password:"
   flashes:
     failure_after_create: Bad email or password.
     failure_after_update: Password can't be blank.

--- a/spec/mailers/clearance_mailer_spec.rb
+++ b/spec/mailers/clearance_mailer_spec.rb
@@ -1,35 +1,64 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe ClearanceMailer do
-  before do
-    @user  = create(:user)
-    @user.forgot_password!
-    @email = ClearanceMailer.change_password(@user)
+  it "is from DO_NOT_REPLY" do
+    user = create(:user)
+    user.forgot_password!
+
+    email = ClearanceMailer.change_password(user)
+
+    expect(Clearance.configuration.mailer_sender).to eq(email.from[0])
   end
 
-  it 'is from DO_NOT_REPLY' do
-    expect(Clearance.configuration.mailer_sender).to match(/#{@email.from[0]}/i)
+  it "is sent to user" do
+    user = create(:user)
+    user.forgot_password!
+
+    email = ClearanceMailer.change_password(user)
+
+    expect(email.to.first).to eq(user.email)
   end
 
-  it 'is sent to user' do
-    expect(@email.to.first).to match(/#{@user.email}/i)
-  end
-
-  it 'contains a link to edit the password' do
+  it "contains a link to edit the password" do
+    user = create(:user)
+    user.forgot_password!
     host = ActionMailer::Base.default_url_options[:host]
-    regexp = %r{http://#{host}/users/#{@user.id}/password/edit\?token=#{@user.confirmation_token}}
-    expect(@email.body.to_s).to match(regexp)
+    link = "http://#{host}/users/#{user.id}/password/edit" \
+      "?token=#{user.confirmation_token}"
+
+    email = ClearanceMailer.change_password(user)
+
+    expect(email.body.to_s).to include(link)
   end
 
-  it 'sets its subject' do
-    expect(@email.subject).to match(/Change your password/)
+  it "sets its subject" do
+    user = create(:user)
+    user.forgot_password!
+
+    email = ClearanceMailer.change_password(user)
+
+    expect(email.subject).to include("Change your password")
   end
 
-  it 'contains opening text in the body' do
-    expect(@email.body).to match(/a link to change your password/)
+  it "contains opening text in the body" do
+    user = create(:user)
+    user.forgot_password!
+
+    email = ClearanceMailer.change_password(user)
+
+    expect(email.body).to include(
+      I18n.t("clearance_mailer.change_password.opening")
+    )
   end
 
-  it 'contains closing text in the body' do
-    expect(@email.body).to match(/Your password has not been changed/)
+  it "contains closing text in the body" do
+    user = create(:user)
+    user.forgot_password!
+
+    email = ClearanceMailer.change_password(user)
+
+    expect(email.body.raw_source).to include(
+      I18n.t("clearance_mailer.change_password.closing")
+    )
   end
 end


### PR DESCRIPTION
- Remove `before` block
- Use I18n translations where available
- Separate setup, exercise, expectation
- Move to double quotes
- Add `raw` to email body to avoid weird character encoding
