### PR TITLE
Dont set cookie header if not present

### DIFF
--- a/lib/clearance/session.rb
+++ b/lib/clearance/session.rb
@@ -9,7 +9,9 @@ module Clearance
     end
 
     def add_cookie_to_headers(headers)
-      Rack::Utils.set_cookie_header!(headers, REMEMBER_TOKEN_COOKIE, cookie_value)
+      if cookie_value[:value].present?
+        Rack::Utils.set_cookie_header!(headers, REMEMBER_TOKEN_COOKIE, cookie_value)
+      end
     end
 
     def current_user

--- a/spec/clearance/session_spec.rb
+++ b/spec/clearance/session_spec.rb
@@ -320,7 +320,7 @@ describe Clearance::Session do
     headers = {}
     session = Clearance::Session.new(env_without_remember_token)
     session.add_cookie_to_headers headers
-    expect(headers).not_to set_cookie('remember_token')
+    expect(headers["Set-Cookie"]).to be nil
   end
 
   it 'signs out a user' do


### PR DESCRIPTION
[fixes #338]

Trying to fix this problem on rubygems.org which uses clearance. The problem is well described in the issue.

### Solution
clearance always set the response cookie, even when is emtpy, so when doing a redirect, http->https, it would set an empty cookie, which is not what we want.
I cannot see any problem about not setting the cookie when it is empty. (please let me know if I miss something)

I hope CI passes, as I could not run tests locally ( see error: https://gist.github.com/arthurnn/e4bc23aecdc052870b0d )

review @derekprior