### PR TITLE
Fix warnings generated by Clearance

### DIFF
--- a/lib/clearance/configuration.rb
+++ b/lib/clearance/configuration.rb
@@ -27,7 +27,7 @@ module Clearance
     end
 
     def user_model
-      @user_model || ::User
+      @user_model ||= ::User
     end
 
     def allow_sign_up?

--- a/lib/clearance/session.rb
+++ b/lib/clearance/session.rb
@@ -6,6 +6,8 @@ module Clearance
 
     def initialize(env)
       @env = env
+      @current_user = nil
+      @cookies = nil
     end
 
     def add_cookie_to_headers(headers)

--- a/lib/generators/clearance/install/install_generator.rb
+++ b/lib/generators/clearance/install/install_generator.rb
@@ -20,9 +20,9 @@ module Clearance
       end
 
       def create_or_inject_clearance_into_user_model
-        if File.exists? 'app/models/user.rb'
+        if File.exist? "app/models/user.rb"
           inject_into_file(
-            'app/models/user.rb',
+            "app/models/user.rb",
             "include Clearance::User\n\n",
             after: "class User < ActiveRecord::Base\n"
           )

--- a/spec/models/password_strategies_spec.rb
+++ b/spec/models/password_strategies_spec.rb
@@ -3,6 +3,8 @@ require 'spec_helper'
 describe Clearance::User do
   subject do
     class UniquenessValidator < ActiveModel::Validator
+      undef validate
+
       def validate(record)
       end
     end

--- a/spec/support/generator_spec_helpers.rb
+++ b/spec/support/generator_spec_helpers.rb
@@ -15,7 +15,8 @@ module GeneratorSpecHelpers
 
   def provide_existing_user_class
     copy_to_generator_root("app/models", "user.rb")
-    allow(File).to receive(:exists?).with("app/models/user.rb").and_return(true)
+    allow(File).to receive(:exist?).and_call_original
+    allow(File).to receive(:exist?).with("app/models/user.rb").and_return(true)
   end
 
   private


### PR DESCRIPTION
* Instance variables should be defined in initializers before used
* `File.exists?` is deprecated

This does not address the "possible reference to past scope" warnings
introduced with Ruby 2.2.0 as it appears this warning will be removed in
2.2.1. See https://bugs.ruby-lang.org/issues/10661