### PR TITLE
Rename `authorize` filter to `require_login`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 Thank you to all the [contributors](https://github.com/thoughtbot/clearance/graphs/contributors)!
 
+New on Master
+* The `authorize` filter has been deprecated in favor of `require_login`. Update
+  all reference to the filter including any calls to `skip_before_filter` or
+  `skip_before_action`.
+
 New for 1.6.1 (January 6, 2015)
 * Secure cookies are no longer overwritten when the user visits a non-HTTPS URL.
 

--- a/README.md
+++ b/README.md
@@ -100,11 +100,11 @@ Clearance.configure do |config|
 end
 ```
 
-Use `authorize` to control access in controllers:
+Use `require_login` to control access in controllers:
 
 ```ruby
 class ArticlesController < ApplicationController
-  before_filter :authorize
+  before_filter :require_login
 
   def index
     current_user.articles
@@ -460,10 +460,10 @@ Run the specs:
 
     rake
 
-Testing authorized controller actions
--------------------------------------
+Testing controller actions that require login
+---------------------------------------------
 
-To test controller actions that are protected by `before_filter :authorize`,
+To test controller actions that are protected by `before_filter :require_login`,
 require Clearance's test helpers and matchers in your test suite.
 
 For `rspec`, add this line to your `spec/spec_helper.rb`:

--- a/app/controllers/clearance/passwords_controller.rb
+++ b/app/controllers/clearance/passwords_controller.rb
@@ -1,7 +1,7 @@
 require 'active_support/deprecation'
 
 class Clearance::PasswordsController < Clearance::BaseController
-  skip_before_filter :authorize, only: [:create, :edit, :new, :update]
+  skip_before_filter :require_login, only: [:create, :edit, :new, :update]
   before_filter :forbid_missing_token, only: [:edit, :update]
   before_filter :forbid_non_existent_user, only: [:edit, :update]
 

--- a/app/controllers/clearance/sessions_controller.rb
+++ b/app/controllers/clearance/sessions_controller.rb
@@ -1,5 +1,5 @@
 class Clearance::SessionsController < Clearance::BaseController
-  skip_before_filter :authorize, only: [:create, :new, :destroy]
+  skip_before_filter :require_login, only: [:create, :new, :destroy]
   protect_from_forgery except: :create
 
   def create

--- a/app/controllers/clearance/users_controller.rb
+++ b/app/controllers/clearance/users_controller.rb
@@ -1,5 +1,5 @@
 class Clearance::UsersController < Clearance::BaseController
-  skip_before_filter :authorize, only: [:create, :new]
+  skip_before_filter :require_login, only: [:create, :new]
   before_filter :avoid_sign_in, only: [:create, :new], if: :signed_in?
 
   def new

--- a/lib/clearance/authorization.rb
+++ b/lib/clearance/authorization.rb
@@ -3,13 +3,21 @@ module Clearance
     extend ActiveSupport::Concern
 
     included do
-      hide_action :authorize, :deny_access
+      hide_action :authorize, :deny_access, :require_login
     end
 
-    def authorize
+    def require_login
       unless signed_in?
         deny_access
       end
+    end
+
+    def authorize
+      warn "[DEPRECATION] Clearance's `authorize` before_filter is " +
+        "deprecated. Use `require_login` instead. Be sure to update any " +
+        "instances of `skip_before_filter :authorize` or " +
+        "`skip_before_action :authorize` as well"
+      require_login
     end
 
     def deny_access(flash_message = nil)

--- a/spec/controllers/apis_controller_spec.rb
+++ b/spec/controllers/apis_controller_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 class ApisController < ActionController::Base
   include Clearance::Controller
 
-  before_filter :authorize
+  before_filter :require_login
 
   def show
     render text: 'response'

--- a/spec/controllers/forgeries_controller_spec.rb
+++ b/spec/controllers/forgeries_controller_spec.rb
@@ -4,7 +4,7 @@ class ForgeriesController < ActionController::Base
   include Clearance::Controller
 
   protect_from_forgery
-  before_filter :authorize
+  before_filter :require_login
 
   # This is off in test by default, but we need it for this test
   self.allow_forgery_protection = true

--- a/spec/controllers/permissions_controller_spec.rb
+++ b/spec/controllers/permissions_controller_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 class PermissionsController < ActionController::Base
   include Clearance::Controller
 
-  before_filter :authorize, only: :show
+  before_filter :require_login, only: :show
 
   def new
     render text: 'New page'


### PR DESCRIPTION
This name better expresses the intent of the filter and has the advantage of
not conflicting with the `authorize` method provided by pundit or wading into
the sometimes hairy line demarcating authorization from authentication.

Clearance users should migrate from `:authorize` to `require_login` as the
former will be removed in 2.0. Be sure to catch reference to
`skip_before_filter :authorize` or `skip_before_action :authorize`, which the
deprecation cannot catch.

addresses #503, #436, and #239