### PR TITLE
Deprecate `Clearance.root`

### DIFF
--- a/lib/clearance.rb
+++ b/lib/clearance.rb
@@ -11,6 +11,9 @@ require 'clearance/constraints'
 
 module Clearance
   def self.root
+    warn "#{Kernel.caller.first}: [DEPRECATION] `Clearance.root` is " +
+      "deprecated and will be removed in the next major release. If you need " +
+      "to find Clearance's root, you can use the `Gem::Specification` API."
     File.expand_path('../..', __FILE__)
   end
 end

--- a/lib/generators/clearance/views/views_generator.rb
+++ b/lib/generators/clearance/views/views_generator.rb
@@ -3,7 +3,7 @@ require 'rails/generators/base'
 module Clearance
   module Generators
     class ViewsGenerator < Rails::Generators::Base
-      source_root Clearance.root
+      source_root File.expand_path("../../../../..", __FILE__)
 
       def create_views
         views.each do |view|


### PR DESCRIPTION
This appears to have been a convenience method used only in a single
generator. While the replacement is uglier it has the distinct advantage of
not leaking into the public API of the gem.