### PR TITLE
Stop specifying a range of copyright years

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License
 
-Copyright (c) 2009-2014 thoughtbot, inc.
+Copyright (c) 2009 thoughtbot, inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
The date of firts publication seems sufficient and it prevents us from having
to update a range of years every year.