### PR TITLE
Prevent redirect loops when still using `authorize`

### DIFF
--- a/app/controllers/clearance/passwords_controller.rb
+++ b/app/controllers/clearance/passwords_controller.rb
@@ -2,6 +2,7 @@ require 'active_support/deprecation'
 
 class Clearance::PasswordsController < Clearance::BaseController
   skip_before_filter :require_login, only: [:create, :edit, :new, :update]
+  skip_before_filter :authorize, only: [:create, :edit, :new, :update]
   before_filter :forbid_missing_token, only: [:edit, :update]
   before_filter :forbid_non_existent_user, only: [:edit, :update]
 

--- a/app/controllers/clearance/sessions_controller.rb
+++ b/app/controllers/clearance/sessions_controller.rb
@@ -1,6 +1,7 @@
 class Clearance::SessionsController < Clearance::BaseController
   before_filter :redirect_signed_in_users, only: [:new]
   skip_before_filter :require_login, only: [:create, :new, :destroy]
+  skip_before_filter :authorize, only: [:create, :new, :destroy]
   protect_from_forgery except: :create
 
   def create

--- a/app/controllers/clearance/users_controller.rb
+++ b/app/controllers/clearance/users_controller.rb
@@ -1,6 +1,7 @@
 class Clearance::UsersController < Clearance::BaseController
   before_filter :redirect_signed_in_users, only: [:create, :new]
   skip_before_filter :require_login, only: [:create, :new]
+  skip_before_filter :authorize, only: [:create, :new]
 
   def new
     @user = user_from_params


### PR DESCRIPTION
The `authorize` before filter is deprecated in favor of `require_login`.
However, just switching Clearance's internal filters is not sufficient. We're
dependent on users updating any `before_filter :authorize` calls.

If they still have `before_filter :authorize` in their application controller,
then they will see a deprecation on calls to authorize but the method will
still run (it's aliased to `require_login`). This may cause them to be
redirected to sign in. Sign in is set to
`skip_before_filter :require_login`, but will happily still run authorize if
instructed to by the application controller. Then you're stuck in a redirect
loop.

By duplicating the `skip_before_filter` calls to also skip `authorize` we can
be sure this doesn't happen.