### PR TITLE
Configure remember token cookie name

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Clearance.configure do |config|
   config.allow_sign_up = true
   config.cookie_domain = '.example.com'
   config.cookie_expiration = lambda { |cookies| 1.year.from_now.utc }
+  config.cookie_name = 'remember_token'
   config.cookie_path = '/'
   config.routes = true
   config.httponly = false

--- a/lib/clearance/configuration.rb
+++ b/lib/clearance/configuration.rb
@@ -5,6 +5,7 @@ module Clearance
     attr_accessor \
       :cookie_domain,
       :cookie_expiration,
+      :cookie_name,
       :cookie_path,
       :httponly,
       :mailer_sender,
@@ -18,6 +19,7 @@ module Clearance
       @allow_sign_up = true
       @cookie_expiration = ->(cookies) { 1.year.from_now.utc }
       @cookie_path = '/'
+      @cookie_name = "remember_token"
       @httponly = false
       @mailer_sender = 'reply@example.com'
       @redirect_url = '/'

--- a/lib/clearance/session.rb
+++ b/lib/clearance/session.rb
@@ -2,8 +2,6 @@ require 'clearance/default_sign_in_guard'
 
 module Clearance
   class Session
-    REMEMBER_TOKEN_COOKIE = 'remember_token'.freeze
-
     def initialize(env)
       @env = env
       @current_user = nil
@@ -12,7 +10,11 @@ module Clearance
 
     def add_cookie_to_headers(headers)
       if cookie_value[:value].present?
-        Rack::Utils.set_cookie_header!(headers, REMEMBER_TOKEN_COOKIE, cookie_value)
+        Rack::Utils.set_cookie_header!(
+          headers,
+          remember_token_cookie,
+          cookie_value
+        )
       end
     end
 
@@ -29,7 +31,7 @@ module Clearance
       status = run_sign_in_stack
 
       if status.success?
-        cookies[REMEMBER_TOKEN_COOKIE] = user && user.remember_token
+        cookies[remember_token_cookie] = user && user.remember_token
       else
         @current_user = nil
       end
@@ -45,7 +47,7 @@ module Clearance
       end
 
       @current_user = nil
-      cookies.delete REMEMBER_TOKEN_COOKIE
+      cookies.delete remember_token_cookie
     end
 
     def signed_in?
@@ -63,7 +65,7 @@ module Clearance
     end
 
     def remember_token
-      cookies[REMEMBER_TOKEN_COOKIE]
+      cookies[remember_token_cookie]
     end
 
     def remember_token_expires
@@ -76,6 +78,10 @@ module Clearance
           'lambda should accept the collection of previously set cookies.'
         expires_configuration.call
       end
+    end
+
+    def remember_token_cookie
+      Clearance.configuration.cookie_name.freeze
     end
 
     def expires_configuration

--- a/spec/clearance/session_spec.rb
+++ b/spec/clearance/session_spec.rb
@@ -30,6 +30,19 @@ describe Clearance::Session do
     expect(session.current_user).to be_nil
   end
 
+  context "with a custom cookie name" do
+    it "sets a custom cookie name in the header" do
+      Clearance.configuration.cookie_domain = "custom_token"
+
+      session.sign_in user
+      session.add_cookie_to_headers(headers)
+
+      expect(headers["Set-Cookie"]).to match(/custom_token/)
+    end
+
+    after { restore_default_config }
+  end
+
   describe '#sign_in' do
     it 'sets current_user' do
       user = build(:user)

--- a/spec/support/request_with_remember_token.rb
+++ b/spec/support/request_with_remember_token.rb
@@ -2,7 +2,7 @@ module RememberTokenHelpers
   def request_with_remember_token(remember_token)
     cookies = {
       'action_dispatch.cookies' => {
-        Clearance::Session::REMEMBER_TOKEN_COOKIE => remember_token
+        Clearance.configuration.cookie_name => remember_token
       }
     }
     env = { clearance: Clearance::Session.new(cookies) }


### PR DESCRIPTION
Gives the user full configurability when dealing with apps with similar paths.