### PR TITLE
Enable forgery protection on sessions#create

### DIFF
--- a/app/controllers/clearance/sessions_controller.rb
+++ b/app/controllers/clearance/sessions_controller.rb
@@ -2,7 +2,6 @@ class Clearance::SessionsController < Clearance::BaseController
   before_filter :redirect_signed_in_users, only: [:new]
   skip_before_filter :require_login, only: [:create, :new, :destroy]
   skip_before_filter :authorize, only: [:create, :new, :destroy]
-  protect_from_forgery except: :create
 
   def create
     @user = authenticate(params)


### PR DESCRIPTION
This line has existed since 2008, and yet I can determine no justification for
it. It seems to me that we *would* want CSRF protection on `session#create`.

On its own, skipping CSRF protection in just this single action doesn't seem
particularly useful to an attacker. Additional vectors (such as an
overly-permissive CORS header) would have to be present to make use of this,
but at that point far more interesting attacks would be possible on any
cookie-based auth system.