### PR TITLE
Don't expose authentication methods as actions

### DIFF
--- a/lib/clearance/authentication.rb
+++ b/lib/clearance/authentication.rb
@@ -5,8 +5,10 @@ module Clearance
     included do
       helper_method :current_user, :signed_in?, :signed_out?
       hide_action(
+        :authenticate,
         :current_user,
         :current_user=,
+        :handle_unverified_request,
         :sign_in,
         :sign_out,
         :signed_in?,

--- a/spec/clearance/contoller_spec.rb
+++ b/spec/clearance/contoller_spec.rb
@@ -1,0 +1,11 @@
+require "spec_helper"
+
+describe "Clearance::Controller", type: :controller do
+  controller(ActionController::Base) do
+    include Clearance::Controller
+  end
+
+  it "does not expose any action_methods" do
+    expect(controller.action_methods).to be_empty
+  end
+end

--- a/spec/clearance/controller_spec.rb
+++ b/spec/clearance/controller_spec.rb
@@ -1,0 +1,11 @@
+require "spec_helper"
+
+describe Clearance::Controller, type: :controller do
+  controller(ActionController::Base) do
+    include Clearance::Controller
+  end
+
+  it "exposes no action methods" do
+    expect(controller.action_methods).to be_empty
+  end
+end


### PR DESCRIPTION
There were a couple of methods from the Clearance::Authentication that were
leaking through to become routable action methods on the controller. We need
to hide them as actions.