### PR TITLE
Allow User model to be reloaded in development

### DIFF
--- a/lib/clearance/configuration.rb
+++ b/lib/clearance/configuration.rb
@@ -133,6 +133,17 @@ module Clearance
     def routes_enabled?
       @routes
     end
+
+    # Reloads the clearance user model class.
+    # This is called from the Clearance engine to reload the configured
+    # user class during each request while in development mode, but only once
+    # in production.
+    # @private
+    def reload_user_model
+      if @user_model.present?
+        @user_model = @user_model.to_s.constantize
+      end
+    end
   end
 
   # @return [Clearance::Configuration] Clearance's current configuration

--- a/lib/clearance/engine.rb
+++ b/lib/clearance/engine.rb
@@ -1,12 +1,15 @@
-require 'clearance'
-require 'rails'
+require "clearance"
+require "rails"
 
 module Clearance
   class Engine < Rails::Engine
-    initializer 'clearance.filter' do |app|
+    initializer "clearance.filter" do |app|
       app.config.filter_parameters += [:password, :token]
     end
 
-    config.app_middleware.insert_after ActionDispatch::ParamsParser, Clearance::RackSession
+    config.app_middleware.insert_after(
+      ActionDispatch::ParamsParser,
+      Clearance::RackSession
+    )
   end
 end

--- a/lib/clearance/engine.rb
+++ b/lib/clearance/engine.rb
@@ -11,5 +11,9 @@ module Clearance
       ActionDispatch::ParamsParser,
       Clearance::RackSession
     )
+
+    config.to_prepare do
+      Clearance.configuration.reload_user_model
+    end
   end
 end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -162,4 +162,19 @@ describe Clearance::Configuration do
       expect(Clearance.configuration.routes_enabled?).to be false
     end
   end
+
+  describe "#reload_user_model" do
+    it "returns the user model class if one has already been configured" do
+      ConfiguredUser = Class.new
+      Clearance.configure { |config| config.user_model = ConfiguredUser }
+
+      expect(Clearance.configuration.reload_user_model).to eq ConfiguredUser
+    end
+
+    it "returns nil if the user_model has not been configured" do
+      Clearance.configuration = Clearance::Configuration.new
+
+      expect(Clearance.configuration.reload_user_model).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
When a `user_model` is configured in a Clearance initializer, a reference
to that class is immediately saved off. If that class is changed, Clearance
will not know to automatically reload the class as Rails does automatically
for classes in development.

This change introduces a `to_prepare` block to the Engine that is
responsible for forcing the configured user class to be reloaded.
`to_prepare` runs once per request in development and only at startup in
other environments.