### PR TITLE
Correct unnecessary spacing in migration file

### DIFF
--- a/db/migrate/20110111224543_create_clearance_users.rb
+++ b/db/migrate/20110111224543_create_clearance_users.rb
@@ -1,6 +1,6 @@
 class CreateClearanceUsers < ActiveRecord::Migration
   def self.up
-    create_table :users  do |t|
+    create_table :users do |t|
       t.timestamps null: false
       t.string :email, null: false
       t.string :encrypted_password, limit: 128, null: false


### PR DESCRIPTION
This is a small correction to stop tools such as HoundCi throwing an
`Unnecessary spacing detected` comment.

While a very minor change, it is one less "fix and rebase" step during code
review.