### PR TITLE
Include a text part for change password mailer

### DIFF
--- a/app/views/clearance_mailer/change_password.text.erb
+++ b/app/views/clearance_mailer/change_password.text.erb
@@ -1,0 +1,5 @@
+<%= t(".opening") %></p>
+
+<%= edit_user_password_url(@user, token: @user.confirmation_token.html_safe) %>
+
+<%= raw t(".closing") %>

--- a/lib/generators/clearance/specs/templates/features/clearance/visitor_resets_password_spec.rb.tt
+++ b/lib/generators/clearance/specs/templates/features/clearance/visitor_resets_password_spec.rb.tt
@@ -47,7 +47,8 @@ feature "Visitor resets password" do
     message = ActionMailer::Base.deliveries.any? do |email|
       email.to == [recipient] &&
         email.subject =~ /#{subject}/i &&
-        email.body =~ /#{body}/
+        email.html_part.body =~ /#{body}/
+        email.text_part.body =~ /#{body}/
     end
 
     expect(message).to be

--- a/spec/generators/clearance/views/views_generator_spec.rb
+++ b/spec/generators/clearance/views/views_generator_spec.rb
@@ -6,18 +6,19 @@ describe Clearance::Generators::ViewsGenerator, :generator do
     run_generator
 
     views = %w(
-      clearance_mailer/change_password
-      layouts/application
-      passwords/create
-      passwords/edit
-      passwords/new
-      sessions/_form
-      sessions/new
-      users/_form
-      users/new
+      clearance_mailer/change_password.html.erb
+      clearance_mailer/change_password.text.erb
+      layouts/application.html.erb
+      passwords/create.html.erb
+      passwords/edit.html.erb
+      passwords/new.html.erb
+      sessions/_form.html.erb
+      sessions/new.html.erb
+      users/_form.html.erb
+      users/new.html.erb
     )
 
-    view_files = views.map { |view| file("app/views/#{view}.html.erb") }
+    view_files = views.map { |view| file("app/views/#{view}") }
 
     view_files.each do |each|
       expect(each).to exist

--- a/spec/mailers/clearance_mailer_spec.rb
+++ b/spec/mailers/clearance_mailer_spec.rb
@@ -19,21 +19,6 @@ describe ClearanceMailer do
     expect(email.to.first).to eq(user.email)
   end
 
-  it "contains a link to edit the password" do
-    user = create(:user)
-    user.forgot_password!
-    host = ActionMailer::Base.default_url_options[:host]
-    link = "http://#{host}/users/#{user.id}/password/edit" \
-      "?token=#{user.confirmation_token}"
-
-    email = ClearanceMailer.change_password(user)
-
-    expect(email.body.to_s).to include(link)
-    expect(email.body.to_s).to have_css(
-      "a", text: I18n.t("clearance_mailer.change_password.link_text")
-    )
-  end
-
   it "sets its subject" do
     user = create(:user)
     user.forgot_password!
@@ -43,25 +28,31 @@ describe ClearanceMailer do
     expect(email.subject).to include("Change your password")
   end
 
-  it "contains opening text in the body" do
+  it "has html and plain text parts" do
     user = create(:user)
     user.forgot_password!
 
     email = ClearanceMailer.change_password(user)
 
-    expect(email.body).to include(
-      I18n.t("clearance_mailer.change_password.opening")
-    )
+    expect(email.body.parts.length).to eq 2
+    expect(email.text_part).to be_present
+    expect(email.html_part).to be_present
   end
 
-  it "contains closing text in the body" do
+  it "contains a link to edit the password" do
     user = create(:user)
     user.forgot_password!
+    host = ActionMailer::Base.default_url_options[:host]
+    link = "http://#{host}/users/#{user.id}/password/edit" \
+      "?token=#{user.confirmation_token}"
 
     email = ClearanceMailer.change_password(user)
 
-    expect(email.body.raw_source).to include(
-      I18n.t("clearance_mailer.change_password.closing")
+    expect(email.text_part.body).to include(link)
+    expect(email.html_part.body).to include(link)
+    expect(email.html_part.body).to have_css(
+      "a",
+      text: I18n.t("clearance_mailer.change_password.link_text")
     )
   end
 end


### PR DESCRIPTION
It's best practice to send a text part when sending HTML email. It's
relatively simple for us to do so here even at the cost of some
duplication.