### PR TITLE
Use the same syntax for all translations in the views

### DIFF
--- a/app/views/clearance_mailer/change_password.html.erb
+++ b/app/views/clearance_mailer/change_password.html.erb
@@ -1,8 +1,8 @@
-<p><%= t(".opening") %></p>
+<p><%= t('.opening') %></p>
 
 <p>
-  <%= link_to t(".link_text", default: "Change my password"),
+  <%= link_to t('.link_text', default: "Change my password"),
     edit_user_password_url(@user, token: @user.confirmation_token.html_safe) %>
 </p>
 
-<p><%= raw t(".closing") %></p>
+<p><%= raw t('.closing') %></p>

--- a/app/views/clearance_mailer/change_password.text.erb
+++ b/app/views/clearance_mailer/change_password.text.erb
@@ -1,5 +1,5 @@
-<%= t(".opening") %></p>
+<%= t('.opening') %></p>
 
 <%= edit_user_password_url(@user, token: @user.confirmation_token.html_safe) %>
 
-<%= raw t(".closing") %>
+<%= raw t('.closing') %>

--- a/app/views/passwords/create.html.erb
+++ b/app/views/passwords/create.html.erb
@@ -1,3 +1,3 @@
 <div id="clearance" class="password-reset">
-  <p><%= t '.description' %></p>
+  <p><%= t('.description') %></p>
 </div>

--- a/app/views/passwords/edit.html.erb
+++ b/app/views/passwords/edit.html.erb
@@ -1,7 +1,7 @@
 <div id="clearance" class="password-reset">
-  <h2><%= t '.title' %></h2>
+  <h2><%= t('.title') %></h2>
 
-  <p><%= t '.description' %></p>
+  <p><%= t('.description') %></p>
 
   <%= form_for :password_reset,
         url: user_password_path(@user, token: @user.confirmation_token),

--- a/app/views/passwords/new.html.erb
+++ b/app/views/passwords/new.html.erb
@@ -1,7 +1,7 @@
 <div id="clearance" class="password-reset">
-  <h2><%= t '.title' %></h2>
+  <h2><%= t('.title') %></h2>
 
-  <p><%= t '.description' %></p>
+  <p><%= t('.description') %></p>
 
   <%= form_for :password, url: passwords_path do |form| %>
     <div class="text-field">

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,5 +1,5 @@
 <div id="clearance" class="sign-in">
-  <h2><%= t '.title' %></h2>
+  <h2><%= t('.title') %></h2>
 
   <%= render partial: '/sessions/form' %>
 


### PR DESCRIPTION
The syntax for translations is inconsistent between different views and mail templates.

It might be that I am unaware of some style guideline regarding this, but using `t('.title')` seems to be a good compromise.