### PR TITLE
Use the same style for all translations in the views

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,9 +7,9 @@
 <body>
   <div id="header">
     <% if signed_in? -%>
-      <%= button_to t('.sign_out'), sign_out_path, method: :delete %>
+      <%= button_to t(".sign_out"), sign_out_path, method: :delete %>
     <% else -%>
-      <%= link_to t('.sign_in'), sign_in_path %>
+      <%= link_to t(".sign_in"), sign_in_path %>
     <% end -%>
   </div>
 

--- a/app/views/passwords/create.html.erb
+++ b/app/views/passwords/create.html.erb
@@ -1,3 +1,3 @@
 <div id="clearance" class="password-reset">
-  <p><%= t '.description' %></p>
+  <p><%= t(".description") %></p>
 </div>

--- a/app/views/passwords/edit.html.erb
+++ b/app/views/passwords/edit.html.erb
@@ -1,7 +1,7 @@
 <div id="clearance" class="password-reset">
-  <h2><%= t '.title' %></h2>
+  <h2><%= t(".title") %></h2>
 
-  <p><%= t '.description' %></p>
+  <p><%= t(".description") %></p>
 
   <%= form_for :password_reset,
         url: user_password_path(@user, token: @user.confirmation_token),

--- a/app/views/passwords/new.html.erb
+++ b/app/views/passwords/new.html.erb
@@ -1,7 +1,7 @@
 <div id="clearance" class="password-reset">
-  <h2><%= t '.title' %></h2>
+  <h2><%= t(".title") %></h2>
 
-  <p><%= t '.description' %></p>
+  <p><%= t(".description") %></p>
 
   <%= form_for :password, url: passwords_path do |form| %>
     <div class="text-field">

--- a/app/views/sessions/_form.html.erb
+++ b/app/views/sessions/_form.html.erb
@@ -15,8 +15,8 @@
 
   <div class="other-links">
     <% if Clearance.configuration.allow_sign_up? %>
-      <%= link_to t('.sign_up'), sign_up_path %>
+      <%= link_to t(".sign_up"), sign_up_path %>
     <% end %>
-    <%= link_to t('.forgot_password'), new_password_path %>
+    <%= link_to t(".forgot_password"), new_password_path %>
   </div>
 <% end %>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,5 +1,5 @@
 <div id="clearance" class="sign-in">
-  <h2><%= t '.title' %></h2>
+  <h2><%= t(".title") %></h2>
 
   <%= render partial: '/sessions/form' %>
 

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,5 +1,5 @@
 <div id="clearance" class="sign-up">
-  <h2><%= t('.title') %></h2>
+  <h2><%= t(".title") %></h2>
 
   <%= form_for @user do |form| %>
     <%= render partial: '/users/form', object: form %>
@@ -9,7 +9,7 @@
     </div>
 
     <div class="other-links">
-      <%= link_to t('.sign_in'), sign_in_path %>
+      <%= link_to t(".sign_in"), sign_in_path %>
     </div>
   <% end %>
 </div>


### PR DESCRIPTION
(reopened with fixed branch name & commit messages)

The style for translations is inconsistent between different views and mail templates.

It might be that I am unaware of some style guideline regarding this, but using t(".title") seems to be a good compromise.