### PR TITLE
url_after_denied_access_when_signed_out missing in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ sessions#url_after_create
 sessions#url_for_signed_in_users
 users#url_after_create
 application#url_after_denied_access_when_signed_in
+application#url_after_denied_access_when_signed_out
 ```
 
 To override them all at once, change the global configuration of `redirect_url`.


### PR DESCRIPTION
Add `application#url_after_denied_access_when_signed_out` to the README