### PR TITLE
Deprecate unused password strategies

### DIFF
--- a/lib/clearance/password_strategies/bcrypt_migration_from_sha1.rb
+++ b/lib/clearance/password_strategies/bcrypt_migration_from_sha1.rb
@@ -1,6 +1,13 @@
 module Clearance
   module PasswordStrategies
     module BCryptMigrationFromSHA1
+      DEPRECATION_MESSAGE = "[DEPRECATION] The BCryptMigrationFromSha1 " \
+        "password strategy has been deprecated and will be removed from " \
+        "Clearance 2.0. BCrypt is the only officially supported strategy, " \
+        "though you are free to provide your own. To continue using this " \
+        "strategy, add clearance-deprecated_password_strategies to your " \
+        "Gemfile."
+
       class BCryptUser
         include Clearance::PasswordStrategies::BCrypt
 
@@ -22,10 +29,12 @@ module Clearance
       end
 
       def authenticated?(password)
+        warn "#{Kernel.caller.first}: #{DEPRECATION_MESSAGE}"
         authenticated_with_sha1?(password) || authenticated_with_bcrypt?(password)
       end
 
       def password=(new_password)
+        warn "#{Kernel.caller.first}: #{DEPRECATION_MESSAGE}"
         @password = new_password
         BCryptUser.new(self).password = new_password
       end

--- a/lib/clearance/password_strategies/blowfish.rb
+++ b/lib/clearance/password_strategies/blowfish.rb
@@ -4,11 +4,19 @@ require 'base64'
 module Clearance
   module PasswordStrategies
     module Blowfish
+      DEPRECATION_MESSAGE = "[DEPRECATION] The Blowfish password strategy " \
+        "has been deprecated and will be removed from Clearance 2.0. BCrypt " \
+        "is the only officially supported strategy, though you are free to " \
+        "provide your own. To continue using this strategy add " \
+        "clearance-deprecated_password_strategies to your Gemfile."
+
       def authenticated?(password)
+        warn "#{Kernel.caller.first}: #{DEPRECATION_MESSAGE}"
         encrypted_password == encrypt(password)
       end
 
       def password=(new_password)
+        warn "#{Kernel.caller.first}: #{DEPRECATION_MESSAGE}"
         @password = new_password
         initialize_salt_if_necessary
 

--- a/lib/clearance/password_strategies/sha1.rb
+++ b/lib/clearance/password_strategies/sha1.rb
@@ -3,13 +3,21 @@ module Clearance
     module SHA1
       require 'digest/sha1'
 
+      DEPRECATION_MESSAGE = "[DEPRECATION] The SHA1 password strategy " \
+        "has been deprecated and will be removed from Clearance 2.0. BCrypt " \
+        "is the only officially supported strategy, though you are free to " \
+        "provide your own. To continue using this strategy add " \
+        "clearance-deprecated_password_strategies to your Gemfile."
+
       extend ActiveSupport::Concern
 
       def authenticated?(password)
+        warn "#{Kernel.caller.first}: #{DEPRECATION_MESSAGE}"
         encrypted_password == encrypt(password)
       end
 
       def password=(new_password)
+        warn "#{Kernel.caller.first}: #{DEPRECATION_MESSAGE}"
         @password = new_password
         initialize_salt_if_necessary
 

--- a/spec/password_strategies/bcrypt_migration_from_sha1_spec.rb
+++ b/spec/password_strategies/bcrypt_migration_from_sha1_spec.rb
@@ -2,6 +2,12 @@ require "spec_helper"
 include FakeModelWithPasswordStrategy
 
 describe Clearance::PasswordStrategies::BCryptMigrationFromSHA1 do
+  around do |example|
+    silence_warnings do
+      example.run
+    end
+  end
+
   describe "#password=" do
     it "encrypts the password into a BCrypt-encrypted encrypted_password" do
       stub_bcrypt_password

--- a/spec/password_strategies/blowfish_spec.rb
+++ b/spec/password_strategies/blowfish_spec.rb
@@ -2,6 +2,12 @@ require "spec_helper"
 include FakeModelWithPasswordStrategy
 
 describe Clearance::PasswordStrategies::Blowfish do
+  around do |example|
+    silence_warnings do
+      example.run
+    end
+  end
+
   describe "#password=" do
     context "when the password is set" do
       it "does not initialize the salt" do

--- a/spec/password_strategies/sha1_spec.rb
+++ b/spec/password_strategies/sha1_spec.rb
@@ -2,6 +2,12 @@ require "spec_helper"
 include FakeModelWithPasswordStrategy
 
 describe Clearance::PasswordStrategies::SHA1 do
+  around do |example|
+    silence_warnings do
+      example.run
+    end
+  end
+
   describe "#password=" do
     context "when the salt is set" do
       it "does not initialize the salt when assigned" do


### PR DESCRIPTION
We don't use `SHA1` or `Blowfish` password strategies. I have no plans
to maintain them moving forward and as an opinionated library Clearance
should be pushing users to `BCrypt`. With `SHA1` being deprecated we
also need to deprecated the `BCryptMigrationFromSHA1` strategy.

These strategies can still be used, deprecation free, by adding the
`clearance-deprecated_password_strategies` gem. We do not intend to
maintain these, but also have no plans to break the interface. Should
maintainers want to keep a particular strategy alive and maintained,
they should extract it.