### PR TITLE
Add support for multiple base domains

### DIFF
--- a/lib/clearance/session.rb
+++ b/lib/clearance/session.rb
@@ -115,10 +115,12 @@ module Clearance
         value: remember_token
       }
 
-      allowed_domains = Array(Clearance.configuration.cookie_domain).map(&:downcase)
+      allowed_domains = Array(Clearance.configuration.cookie_domain).dup
+      allowed_domains.map!(&:downcase)
 
       if allowed_domains.any?
-        value[:domain] = allowed_domains.delete(extract_base_host(get_request_uri))
+        base_host = extract_base_host(get_request_uri)
+        value[:domain] = allowed_domains.delete(base_host)
         value[:domain] ||= allowed_domains.first
       end
 
@@ -129,12 +131,12 @@ module Clearance
 
     def extract_base_host(uri)
       hostname = URI.parse(uri).host
-      hostname.split('.').last(2).join('.').downcase
+      hostname.split(".").last(2).join(".").downcase
     rescue URI::InvalidURIError
     end
 
     def get_request_uri
-      @env['REQUEST_URI']
+      @env["REQUEST_URI"]
     end
   end
 end

--- a/lib/clearance/session.rb
+++ b/lib/clearance/session.rb
@@ -115,11 +115,26 @@ module Clearance
         value: remember_token
       }
 
-      if Clearance.configuration.cookie_domain.present?
-        value[:domain] = Clearance.configuration.cookie_domain
+      allowed_domains = Array(Clearance.configuration.cookie_domain).map(&:downcase)
+
+      if allowed_domains.any?
+        value[:domain] = allowed_domains.delete(extract_base_host(get_request_uri))
+        value[:domain] ||= allowed_domains.first
       end
 
       value
+    end
+
+    private
+
+    def extract_base_host(uri)
+      hostname = URI.parse(uri).host
+      hostname.split('.').last(2).join('.').downcase
+    rescue URI::InvalidURIError
+    end
+
+    def get_request_uri
+      @env['REQUEST_URI']
     end
   end
 end

--- a/spec/clearance/session_spec.rb
+++ b/spec/clearance/session_spec.rb
@@ -55,7 +55,7 @@ describe Clearance::Session do
   end
 
   context "with multiple allowable domains" do
-    let(:session_stubbed){ session.dup }
+    let(:session_stubbed) { session.dup }
 
     before do
       Clearance.configuration.cookie_domain = %w(example.com example.org)
@@ -64,28 +64,32 @@ describe Clearance::Session do
     end
 
     it "permits whitelisted hosts" do
-      allow(session_stubbed).to receive(:get_request_uri).and_return 'http://example.org/foo'
+      allow(session_stubbed).to receive(:get_request_uri).
+        and_return "http://example.org/foo"
       session_stubbed.add_cookie_to_headers(headers)
 
       expect(headers["Set-Cookie"]).to match(/example.org/)
     end
 
     it "defaults to the first whitelisted host when no header is present" do
-      allow(session_stubbed).to receive(:get_request_uri).and_return 'http://127.0.0.1/foo'
+      allow(session_stubbed).to receive(:get_request_uri).
+        and_return "http://127.0.0.1/foo"
       session_stubbed.add_cookie_to_headers(headers)
 
       expect(headers["Set-Cookie"]).to match(/example.com/)
     end
 
-    it "defaults to the first whitelisted host when other host headers are present" do
-      allow(session_stubbed).to receive(:get_request_uri).and_return 'http://example.net/foo'
+    it "defaults to the first host if the URI doesn't match" do
+      allow(session_stubbed).to receive(:get_request_uri).
+        and_return "http://example.net/foo"
       session_stubbed.add_cookie_to_headers(headers)
 
       expect(headers["Set-Cookie"]).to match(/example.com/)
     end
 
     it "ignores urls that fail to parse for any reason" do
-      allow(session_stubbed).to receive(:get_request_uri).and_return 'invalid domain name'
+      allow(session_stubbed).to receive(:get_request_uri).
+        and_return("invalid domain name")
       session_stubbed.add_cookie_to_headers(headers)
 
       expect(headers["Set-Cookie"]).to match(/example.com/)
@@ -341,7 +345,10 @@ describe Clearance::Session do
     end
 
     context 'when not set' do
-      before { session.sign_in(user) }
+      before do
+        Clearance.configuration.cookie_domain = nil
+        session.sign_in(user)
+      end
 
       it 'sets a standard cookie' do
         session.add_cookie_to_headers(headers)

--- a/spec/clearance/session_spec.rb
+++ b/spec/clearance/session_spec.rb
@@ -43,6 +43,55 @@ describe Clearance::Session do
     after { restore_default_config }
   end
 
+  context "without a custom cookie name" do
+    it "does not specify the cookie domain" do
+      Clearance.configuration.cookie_domain = nil
+
+      session.sign_in user
+      session.add_cookie_to_headers(headers)
+
+      expect(headers["Set-Cookie"]).not_to match(/domain=/)
+    end
+  end
+
+  context "with multiple allowable domains" do
+    let(:session_stubbed){ session.dup }
+
+    before do
+      Clearance.configuration.cookie_domain = %w(example.com example.org)
+
+      session_stubbed.sign_in user
+    end
+
+    it "permits whitelisted hosts" do
+      allow(session_stubbed).to receive(:get_request_uri).and_return 'http://example.org/foo'
+      session_stubbed.add_cookie_to_headers(headers)
+
+      expect(headers["Set-Cookie"]).to match(/example.org/)
+    end
+
+    it "defaults to the first whitelisted host when no header is present" do
+      allow(session_stubbed).to receive(:get_request_uri).and_return 'http://127.0.0.1/foo'
+      session_stubbed.add_cookie_to_headers(headers)
+
+      expect(headers["Set-Cookie"]).to match(/example.com/)
+    end
+
+    it "defaults to the first whitelisted host when other host headers are present" do
+      allow(session_stubbed).to receive(:get_request_uri).and_return 'http://example.net/foo'
+      session_stubbed.add_cookie_to_headers(headers)
+
+      expect(headers["Set-Cookie"]).to match(/example.com/)
+    end
+
+    it "ignores urls that fail to parse for any reason" do
+      allow(session_stubbed).to receive(:get_request_uri).and_return 'invalid domain name'
+      session_stubbed.add_cookie_to_headers(headers)
+
+      expect(headers["Set-Cookie"]).to match(/example.com/)
+    end
+  end
+
   describe '#sign_in' do
     it 'sets current_user' do
       user = build(:user)
@@ -307,6 +356,7 @@ describe Clearance::Session do
       before { session.sign_in(user) }
 
       it 'sets a standard cookie' do
+        Clearance.configuration.cookie_domain = nil
         session.add_cookie_to_headers(headers)
 
         expect(headers['Set-Cookie']).to_not match(/domain=.+; path/)


### PR DESCRIPTION
This PR adds support for a Rails app that serves multiple distinct FQDNs. In other words, one user may log into `client.foo.com` and another may use `other_client.bar.com`. This is not an attempt to allow users to log into `client.foo.com` and then access pages on `other_client.bar.com` -- but rather, to ensure that a single app can issue cookies for multiple base domains.

I recognize that multiple base domains is an undesirable pattern, but it's a reality for many Rails apps. 

This PR adds the ability to pass an array of domains to `Clearance.configuration.cookie_domain`. When issuing a cookie, the server checks to see if the domain in the URI matches any of the configured domains -- if so, it uses the matching domain -- if not, it uses the first domain specified.

NB: the name of the setting probably ought to be pluralized (`cookie_domains`), but we'd need to add an alias to avoid introducing breaking changes. Didn't want to bother with the search & replace until I got some feedback on the concept.

Behavior when a single domain and `nil` are passed to `cookie_domain` is unaltered. This PR should ease headaches when phasing out some bad architectural decisions without affecting people who are Doing It Right.
