### PR TITLE
Strip extra whitespace

### DIFF
--- a/lib/generators/clearance/install/templates/db/migrate/add_clearance_to_users.rb
+++ b/lib/generators/clearance/install/templates/db/migrate/add_clearance_to_users.rb
@@ -1,6 +1,6 @@
 class AddClearanceToUsers < ActiveRecord::Migration
   def self.up
-    change_table :users  do |t|
+    change_table :users do |t|
 <% config[:new_columns].values.each do |column| -%>
       <%= column %>
 <% end -%>

--- a/lib/generators/clearance/install/templates/db/migrate/create_users.rb
+++ b/lib/generators/clearance/install/templates/db/migrate/create_users.rb
@@ -1,6 +1,6 @@
 class CreateUsers < ActiveRecord::Migration
   def change
-    create_table :users  do |t|
+    create_table :users do |t|
       t.timestamps null: false
       t.string :email, null: false
       t.string :encrypted_password, limit: 128, null: false

--- a/lib/generators/clearance/routes/templates/routes.rb
+++ b/lib/generators/clearance/routes/templates/routes.rb
@@ -1,12 +1,12 @@
-resources :passwords, controller: 'clearance/passwords', only: [:create, :new]
-  resource :session, controller: 'clearance/sessions', only: [:create]
+resources :passwords, controller: "clearance/passwords", only: [:create, :new]
+resource :session, controller: "clearance/sessions", only: [:create]
 
-  resources :users, controller: 'clearance/users', only: [:create] do
-    resource :password,
-      controller: 'clearance/passwords',
-      only: [:create, :edit, :update]
-  end
+resources :users, controller: "clearance/users", only: [:create] do
+  resource :password,
+    controller: "clearance/passwords",
+    only: [:create, :edit, :update]
+end
 
-  get '/sign_in' => 'clearance/sessions#new', as: 'sign_in'
-  delete '/sign_out' => 'clearance/sessions#destroy', as: 'sign_out'
-  get '/sign_up' => 'clearance/users#new', as: 'sign_up'
+get "/sign_in" => "clearance/sessions#new", as: "sign_in"
+delete "/sign_out" => "clearance/sessions#destroy", as: "sign_out"
+get "/sign_up" => "clearance/users#new", as: "sign_up"

--- a/spec/generators/clearance/routes/routes_generator_spec.rb
+++ b/spec/generators/clearance/routes/routes_generator_spec.rb
@@ -11,7 +11,7 @@ describe Clearance::Generators::RoutesGenerator, :generator do
 
     expect(routes).to have_correct_syntax
     expect(routes).to contain(
-      "get '/sign_in' => 'clearance/sessions#new', as: 'sign_in'"
+      'get "/sign_in" => "clearance/sessions#new", as: "sign_in"'
     )
   end
 end


### PR DESCRIPTION
When setting up clearance in a recent project I noticed extra whitespace in
some of the generator templates.

This commit removes this whitespace to better conform to the style guide.