### PR TITLE
Only use table transformations in users migration

### DIFF
--- a/lib/generators/clearance/install/templates/db/migrate/create_users.rb
+++ b/lib/generators/clearance/install/templates/db/migrate/create_users.rb
@@ -6,9 +6,8 @@ class CreateUsers < ActiveRecord::Migration
       t.string :encrypted_password, limit: 128, null: false
       t.string :confirmation_token, limit: 128
       t.string :remember_token, limit: 128, null: false
+      t.index :email
+      t.index :remember_token
     end
-
-    add_index :users, :email
-    add_index :users, :remember_token
   end
 end


### PR DESCRIPTION
Previously, the create users migration template was using [table
transformations] for adding columns and [schema statements] for adding
indices.

This commit updates the migration to use table transformations for both of
these purposes.

[table transformations]: http://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/Table.html
[schema statements]: http://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/SchemaStatements.html