### PR TITLE
Move remember token test to model specs

### DIFF
--- a/spec/controllers/passwords_controller_spec.rb
+++ b/spec/controllers/passwords_controller_spec.rb
@@ -101,16 +101,6 @@ describe Clearance::PasswordsController do
         expect(user.reload.encrypted_password).not_to eq old_encrypted_password
       end
 
-      it "sets the remember token and clears the confirmation token" do
-        user = create(:user, :with_forgotten_password)
-
-        put :update, update_parameters(user, new_password: "my_new_password")
-
-        user.reload
-        expect(user.remember_token).not_to be_nil
-        expect(user.confirmation_token).to be_nil
-      end
-
       it "signs the user in and redirects" do
         user = create(:user, :with_forgotten_password)
 
@@ -121,7 +111,7 @@ describe Clearance::PasswordsController do
       end
     end
 
-    context "no password provided" do
+    context "password update fails" do
       it "does not update the password" do
         user = create(:user, :with_forgotten_password)
         old_encrypted_password = user.encrypted_password

--- a/spec/user_spec.rb
+++ b/spec/user_spec.rb
@@ -85,6 +85,15 @@ describe User do
 
         expect(user.confirmation_token).to be_nil
       end
+
+      it "sets the remember token" do
+        user = create(:user, :with_forgotten_password)
+
+        user.update_password("my_new_password")
+
+        user.reload
+        expect(user.remember_token).not_to be_nil
+      end
     end
 
     context "with blank password" do


### PR DESCRIPTION
The controller spec shouldn't know anything about regenerating the remember
token, so the test should be moved over to the User model spec instead.