### PR TITLE
Refactor cookies instance variable to use ActionDispatch::Request.new(@env).cookie_jar

### DIFF
--- a/lib/clearance/session.rb
+++ b/lib/clearance/session.rb
@@ -61,7 +61,7 @@ module Clearance
     private
 
     def cookies
-      @cookies ||= @env['action_dispatch.cookies'] || Rack::Request.new(@env).cookies
+      @cookies ||= ActionDispatch::Request.new(@env).cookie_jar
     end
 
     def remember_token


### PR DESCRIPTION
We are actually running into an issue where `@env['action_dispatch.cookies']` is a empty at some point in the request and causes sign-in not to work in our features and probably in production (we're currently upgrading to Rails 4.0). We haven't been able to trace it down to figure out why exactly it's occurring, but changing it to `ActionDispatch::Request.new(@env).cookie_jar` fixes our issue and still allows all of the gem's tests to pass.