### PR TITLE
Routes generator also disables internal routes

### DIFF
--- a/lib/generators/clearance/routes/routes_generator.rb
+++ b/lib/generators/clearance/routes/routes_generator.rb
@@ -9,6 +9,14 @@ module Clearance
         route(clearance_routes)
       end
 
+      def disable_clearance_internal_routes
+        inject_into_file(
+          "config/initializers/clearance.rb",
+          "  config.routes = false\n",
+          after: "Clearance.configure do |config|\n",
+        )
+      end
+
       private
 
       def clearance_routes

--- a/spec/app_templates/config/initializers/clearance.rb
+++ b/spec/app_templates/config/initializers/clearance.rb
@@ -1,0 +1,2 @@
+Clearance.configure do |config|
+end

--- a/spec/generators/clearance/routes/routes_generator_spec.rb
+++ b/spec/generators/clearance/routes/routes_generator_spec.rb
@@ -4,11 +4,15 @@ require "generators/clearance/routes/routes_generator"
 describe Clearance::Generators::RoutesGenerator, :generator do
   it "adds clearance routes to host application routes" do
     provide_existing_routes_file
+    provide_existing_initializer
 
     routes = file("config/routes.rb")
+    initializer = file("config/initializers/clearance.rb")
 
     run_generator
 
+    expect(initializer).to have_correct_syntax
+    expect(initializer).to contain("config.routes = false")
     expect(routes).to have_correct_syntax
     expect(routes).to contain(
       'get "/sign_in" => "clearance/sessions#new", as: "sign_in"'

--- a/spec/support/generator_spec_helpers.rb
+++ b/spec/support/generator_spec_helpers.rb
@@ -9,6 +9,10 @@ module GeneratorSpecHelpers
     copy_to_generator_root("config", "routes.rb")
   end
 
+  def provide_existing_initializer
+    copy_to_generator_root("config/initializers", "clearance.rb")
+  end
+
   def provide_existing_application_controller
     copy_to_generator_root("app/controllers", "application_controller.rb")
   end


### PR DESCRIPTION
Prior to this change, if you ran the routes generator and then started
your app, it would fail to start because of duplicate named routes. You
were required to manually change your initializer to add `config.routes
= false`. Now the generator does this for you.

Closes #539