### PR TITLE
Document Clearance user module

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,3 +1,4 @@
+--protected
 --private
 --hide-api private
 --exclude templates

--- a/.yardopts
+++ b/.yardopts
@@ -1,3 +1,5 @@
+--private
+--hide-api private
 --exclude templates
 --markup markdown
 --markup-provider redcarpet

--- a/lib/clearance/authentication.rb
+++ b/lib/clearance/authentication.rb
@@ -105,7 +105,7 @@ module Clearance
 
     protected
 
-    # @private
+    # @api private
     def clearance_session
       request.env[:clearance]
     end

--- a/lib/clearance/authorization.rb
+++ b/lib/clearance/authorization.rb
@@ -58,7 +58,7 @@ module Clearance
 
     protected
 
-    # @private
+    # @api private
     def redirect_request(flash_message)
       store_location
 
@@ -73,25 +73,25 @@ module Clearance
       end
     end
 
-    # @private
+    # @api private
     def clear_return_to
       session[:return_to] = nil
     end
 
-    # @private
+    # @api private
     def store_location
       if request.get?
         session[:return_to] = request.original_fullpath
       end
     end
 
-    # @private
+    # @api private
     def redirect_back_or(default)
       redirect_to(return_to || default)
       clear_return_to
     end
 
-    # @private
+    # @api private
     def return_to
       if return_to_url
         uri = URI.parse(return_to_url)
@@ -99,13 +99,14 @@ module Clearance
       end
     end
 
-    # @private
+    # @api private
     def return_to_url
       session[:return_to]
     end
 
     # Used as the redirect location when {#deny_access} is called and there is a
     # currently signed in user.
+    #
     # @return [String]
     def url_after_denied_access_when_signed_in
       Clearance.configuration.redirect_url
@@ -113,6 +114,7 @@ module Clearance
 
     # Used as the redirect location when {#deny_access} is called and there is
     # no currently signed in user.
+    #
     # @return [String]
     def url_after_denied_access_when_signed_out
       sign_in_url

--- a/lib/clearance/back_door.rb
+++ b/lib/clearance/back_door.rb
@@ -29,6 +29,7 @@ module Clearance
 
     private
 
+    # @api private
     def sign_in_through_the_back_door(env)
       params = Rack::Utils.parse_query(env['QUERY_STRING'])
       user_id = params['as']

--- a/lib/clearance/configuration.rb
+++ b/lib/clearance/configuration.rb
@@ -138,7 +138,8 @@ module Clearance
     # This is called from the Clearance engine to reload the configured
     # user class during each request while in development mode, but only once
     # in production.
-    # @private
+    #
+    # @api private
     def reload_user_model
       if @user_model.present?
         @user_model = @user_model.to_s.constantize

--- a/lib/clearance/constraints/signed_in.rb
+++ b/lib/clearance/constraints/signed_in.rb
@@ -29,18 +29,22 @@ module Clearance
 
       private
 
+      # @api private
       def clearance_session
         @request.env[:clearance]
       end
 
+      # @api private
       def current_user
         clearance_session.current_user
       end
 
+      # @api private
       def current_user_fulfills_additional_requirements?
         @block.call current_user
       end
 
+      # @api private
       def signed_in?
         clearance_session.present? && clearance_session.signed_in?
       end

--- a/lib/clearance/constraints/signed_out.rb
+++ b/lib/clearance/constraints/signed_out.rb
@@ -18,10 +18,12 @@ module Clearance
 
       private
 
+      # @api private
       def clearance_session
         @request.env[:clearance]
       end
 
+      # @api private
       def missing_session?
         clearance_session.nil?
       end

--- a/lib/clearance/password_strategies/bcrypt.rb
+++ b/lib/clearance/password_strategies/bcrypt.rb
@@ -25,10 +25,12 @@ module Clearance
 
       private
 
+      # @api private
       def encrypt(password)
         ::BCrypt::Password.create(password, cost: cost)
       end
 
+      # @api private
       def cost
         if test_environment?
           ::BCrypt::Engine::MIN_COST
@@ -37,6 +39,7 @@ module Clearance
         end
       end
 
+      # @api private
       def test_environment?
         defined?(::Rails) && ::Rails.env.test?
       end

--- a/lib/clearance/password_strategies/bcrypt_migration_from_sha1.rb
+++ b/lib/clearance/password_strategies/bcrypt_migration_from_sha1.rb
@@ -9,6 +9,7 @@ module Clearance
         "strategy, add clearance-deprecated_password_strategies to your " \
         "Gemfile."
 
+      # @api private
       class BCryptUser
         include Clearance::PasswordStrategies::BCrypt
 
@@ -19,6 +20,7 @@ module Clearance
         delegate :encrypted_password, :encrypted_password=, to: :@user
       end
 
+      # @api private
       class SHA1User
         include Clearance::PasswordStrategies::SHA1
 
@@ -29,11 +31,15 @@ module Clearance
         delegate :salt, :salt=, :encrypted_password, :encrypted_password=, to: :@user
       end
 
+      # @deprecated Use {BCrypt} or `clearance-deprecated_password_strategies`
+      #   gem
       def authenticated?(password)
         warn "#{Kernel.caller.first}: #{DEPRECATION_MESSAGE}"
         authenticated_with_sha1?(password) || authenticated_with_bcrypt?(password)
       end
 
+      # @deprecated Use {BCrypt} or `clearance-deprecated_password_strategies`
+      #   gem
       def password=(new_password)
         warn "#{Kernel.caller.first}: #{DEPRECATION_MESSAGE}"
         @password = new_password
@@ -42,6 +48,7 @@ module Clearance
 
       private
 
+      # @api private
       def authenticated_with_bcrypt?(password)
         begin
           BCryptUser.new(self).authenticated? password
@@ -50,6 +57,7 @@ module Clearance
         end
       end
 
+      # @api private
       def authenticated_with_sha1?(password)
         if sha1_password?
           if SHA1User.new(self).authenticated? password
@@ -60,6 +68,7 @@ module Clearance
         end
       end
 
+      # @api private
       def sha1_password?
         self.encrypted_password =~ /^[a-f0-9]{40}$/
       end

--- a/lib/clearance/password_strategies/blowfish.rb
+++ b/lib/clearance/password_strategies/blowfish.rb
@@ -11,11 +11,15 @@ module Clearance
         "provide your own. To continue using this strategy add " \
         "clearance-deprecated_password_strategies to your Gemfile."
 
+      # @deprecated Use {BCrypt} or `clearance-deprecated_password_strategies`
+      #   gem
       def authenticated?(password)
         warn "#{Kernel.caller.first}: #{DEPRECATION_MESSAGE}"
         encrypted_password == encrypt(password)
       end
 
+      # @deprecated Use {BCrypt} or `clearance-deprecated_password_strategies`
+      #   gem
       def password=(new_password)
         warn "#{Kernel.caller.first}: #{DEPRECATION_MESSAGE}"
         @password = new_password
@@ -28,10 +32,12 @@ module Clearance
 
       protected
 
+      # @api private
       def encrypt(string)
         generate_hash("--#{salt}--#{string}--")
       end
 
+      # @api private
       def generate_hash(string)
         cipher = OpenSSL::Cipher::Cipher.new('bf-cbc').encrypt
         cipher.key = Digest::SHA256.digest(salt)
@@ -39,12 +45,14 @@ module Clearance
         Base64.encode64(hash).encode('utf-8')
       end
 
+      # @api private
       def initialize_salt_if_necessary
         if salt.blank?
           self.salt = generate_salt
         end
       end
 
+      # @api private
       def generate_salt
         Base64.encode64(SecureRandom.hex(20)).encode('utf-8')
       end

--- a/lib/clearance/password_strategies/sha1.rb
+++ b/lib/clearance/password_strategies/sha1.rb
@@ -12,11 +12,15 @@ module Clearance
 
       extend ActiveSupport::Concern
 
+      # @deprecated Use {BCrypt} or `clearance-deprecated_password_strategies`
+      #   gem
       def authenticated?(password)
         warn "#{Kernel.caller.first}: #{DEPRECATION_MESSAGE}"
         encrypted_password == encrypt(password)
       end
 
+      # @deprecated Use {BCrypt} or `clearance-deprecated_password_strategies`
+      #   gem
       def password=(new_password)
         warn "#{Kernel.caller.first}: #{DEPRECATION_MESSAGE}"
         @password = new_password
@@ -29,20 +33,24 @@ module Clearance
 
       private
 
+      # @api private
       def encrypt(string)
         generate_hash "--#{salt}--#{string}--"
       end
 
+      # @api private
       def generate_hash(string)
         Digest::SHA1.hexdigest(string).encode 'UTF-8'
       end
 
+      # @api private
       def initialize_salt_if_necessary
         if salt.blank?
           self.salt = generate_salt
         end
       end
 
+      # @api private
       def generate_salt
         SecureRandom.hex(20).encode('UTF-8')
       end

--- a/lib/clearance/session.rb
+++ b/lib/clearance/session.rb
@@ -96,14 +96,17 @@ module Clearance
 
     private
 
+    # @api private
     def cookies
       @cookies ||= ActionDispatch::Request.new(@env).cookie_jar
     end
 
+    # @api private
     def remember_token
       cookies[remember_token_cookie]
     end
 
+    # @api private
     def remember_token_expires
       if expires_configuration.arity == 1
         expires_configuration.call(cookies)
@@ -116,23 +119,28 @@ module Clearance
       end
     end
 
+    # @api private
     def remember_token_cookie
       Clearance.configuration.cookie_name.freeze
     end
 
+    # @api private
     def expires_configuration
       Clearance.configuration.cookie_expiration
     end
 
+    # @api private
     def user_from_remember_token(token)
       Clearance.configuration.user_model.where(remember_token: token).first
     end
 
+    # @api private
     def run_sign_in_stack
       @stack ||= initialize_sign_in_guard_stack
       @stack.call
     end
 
+    # @api private
     def initialize_sign_in_guard_stack
       default_guard = DefaultSignInGuard.new(self)
       guards = Clearance.configuration.sign_in_guards
@@ -142,6 +150,7 @@ module Clearance
       end
     end
 
+    # @api private
     def cookie_value
       value = {
         expires: remember_token_expires,

--- a/lib/clearance/testing/controller_helpers.rb
+++ b/lib/clearance/testing/controller_helpers.rb
@@ -5,7 +5,7 @@ module Clearance
     # `clearance/test_unit` as appropriate in your `rails_helper.rb` or
     # `test_helper.rb` files.
     module ControllerHelpers
-      # @private
+      # @api private
       def setup_controller_request_and_response
         super
         @request.env[:clearance] = Clearance::Session.new(@request.env)
@@ -14,6 +14,7 @@ module Clearance
       # Signs in a user that is created using FactoryGirl.
       # The factory name is derrived from your `user_class` Clearance
       # configuration.
+      #
       # @raise [RuntimeError] if FactoryGirl is not defined.
       def sign_in
         unless defined?(FactoryGirl)
@@ -25,12 +26,16 @@ module Clearance
       end
 
       # Signs in the provided user.
+      #
+      # @return user
       def sign_in_as(user)
         @controller.sign_in user
         user
       end
 
       # Signs out a user that may be signed in.
+      #
+      # @return [void]
       def sign_out
         @controller.sign_out
       end

--- a/lib/clearance/testing/deny_access_matcher.rb
+++ b/lib/clearance/testing/deny_access_matcher.rb
@@ -34,7 +34,7 @@ module Clearance
         DenyAccessMatcher.new(self, opts)
       end
 
-      # @private
+      # @api private
       class DenyAccessMatcher
         attr_reader :failure_message, :failure_message_when_negated
 

--- a/lib/clearance/testing/view_helpers.rb
+++ b/lib/clearance/testing/view_helpers.rb
@@ -15,7 +15,7 @@ module Clearance
         view.current_user = user
       end
 
-      # @private
+      # @api private
       module CurrentUser
         attr_accessor :current_user
 

--- a/lib/clearance/user.rb
+++ b/lib/clearance/user.rb
@@ -3,6 +3,102 @@ require 'email_validator'
 require 'clearance/token'
 
 module Clearance
+  # Required to be included in your configued user class, which is `User` by
+  # default, but can be changed with {Configuration#user_model=}.
+  #
+  #     class User
+  #       include Clearance::User
+  #
+  #       # ...
+  #     end
+  #
+  # This will also include methods exposed by your password strategy, which can
+  # be configured with {Configuration#password_strategy=}. By default, this is
+  # {PasswordStrategies::BCrypt}.
+  #
+  # ## Validations
+  #
+  # These validations are added to the class that the {User} module is mixed
+  # into.
+  #
+  # * If {#email_optional?} is false, {#email} is validated for presence,
+  #   uniqueness and email format (using the `email_validator` gem in strict
+  #   mode).
+  # * If {#skip_password_validation?} is false, {#password} is validated
+  #   for presence.
+  #
+  # ## Callbacks
+  #
+  # * {#normalize_email} will be called on `before_validation`
+  # * {#generate_remember_token} will be called on `before_create`
+  #
+  # @!attribute email
+  #   @return [String] The user's email.
+  #
+  # @!attribute encrypted_password
+  #   @return [String] The user's encrypted password.
+  #
+  # @!attribute remember_token
+  #   @return [String] The value used to identify this user in their {Session}
+  #     cookie.
+  #
+  # @!attribute confirmation_token
+  #   @return [String] The value used to identify this user in the password
+  #     reset link.
+  #
+  # @!attribute password_changing
+  #   @return [String] Transient (non-persisted) attribute that is set to
+  #     `true` when {#update_password} is called. This value is read by
+  #     {#skip_password_validation?} to determine if password validations need
+  #     to be run.
+  #
+  # @!attribute [r] password
+  #   @return [String] Transient (non-persisted) attribute that is set when
+  #     updating a user's password. Only the {#encrypted_password} is persisted.
+  #
+  # @!method password=
+  #   Sets the user's encrypted_password by using the configured Password
+  #   Strategy's `password=` method. By default, this will be
+  #   {PasswordStrategies::BCrypt#password=}, but can be changed with
+  #   {Configuration#password_strategy}.
+  #
+  #   @see PasswordStrategies
+  #   @return [void]
+  #
+  # @!method authenticated?
+  #   Check's the provided password against the user's encrypted password using
+  #   the configured password strategy. By default, this will be
+  #   {PasswordStrategies::BCrypt#authenticated?}, but can be changed with
+  #   {Configuration#password_strategy}.
+  #
+  #   @see PasswordStrategies
+  #   @param [String] password
+  #     The password to check.
+  #   @return [Boolean]
+  #     True if the password provided is correct for the user.
+  #
+  # @!method self.authenticate
+  #   Finds the user with the given email and authenticates them with the
+  #   provided password. If the email corresponds to a user and the provided
+  #   password is correct for that user, this method will return that user.
+  #   Otherwise it will return nil.
+  #
+  #   @return [User, nil]
+  #
+  # @!method self.find_by_normalized_email
+  #   Finds the user with the given email. The email with be normalized via
+  #   {#normalize_email}.
+  #
+  #   @return [User, nil]
+  #
+  # @!method self.normalize_email
+  #   Normalizes the provided email by downcasing and removing all spaces.
+  #   This is used by {find_by_normalized_email} and is also called when
+  #   validating a user to ensure only normalized emails are stored in the
+  #   database.
+  #
+  #   @return [String]
+  #
   module User
     extend ActiveSupport::Concern
 
@@ -15,6 +111,7 @@ module Clearance
       include password_strategy
     end
 
+    # @api private
     module ClassMethods
       def authenticate(email, password)
         if user = find_by_normalized_email(email)
@@ -39,6 +136,7 @@ module Clearance
       end
     end
 
+    # @api private
     module Validations
       extend ActiveSupport::Concern
 
@@ -53,6 +151,7 @@ module Clearance
       end
     end
 
+    # @api private
     module Callbacks
       extend ActiveSupport::Concern
 
@@ -62,16 +161,47 @@ module Clearance
       end
     end
 
+    # Generates a {#confirmation_token} for the user, which allows them to reset
+    # their password via an email link.
+    #
+    # Calling `forgot_password!` will cause the user model to be saved without
+    # validations. Any other changes you made to this user instance will also
+    # be persisted, without validation. It is inteded to be called on an
+    # instance with no changes (`dirty? == false`).
+    #
+    # @return [Boolean] Was the save successful?
     def forgot_password!
       generate_confirmation_token
       save validate: false
     end
 
+    # Generates a new {#remember_token} for the user, which will have the effect
+    # of signing all of the user's current sessions out. This is called
+    # internally by {Session#sign_out}.
+    #
+    # Calling `reset_remember_token!` will cause the user model to be saved
+    # without validations. Any other changes you made to this user instance will
+    # also be persisted, without validation. It is inteded to be called on an
+    # instance with no changes (`dirty? == false`).
+    #
+    # @return [Boolean] Was the save successful?
     def reset_remember_token!
       generate_remember_token
       save validate: false
     end
 
+    # Sets the user's password to the new value, using the `password=` method on
+    # the configured password strategy. By default, this is
+    # {PasswordStrategies::BCrypt#password=}.
+    #
+    # This also has the side-effect of blanking the {#confirmation_token} and
+    # rotating the `#remember_token`.
+    #
+    # Validations will be run as part of this update. If the user instance is
+    # not valid, the password change will not be persisted, and this method will
+    # return `false`.
+    #
+    # @return [Boolean] Was the save successful?
     def update_password(new_password)
       self.password_changing = true
       self.password = new_password
@@ -86,28 +216,57 @@ module Clearance
 
     private
 
+    # Sets the email on this instance to the value returned by
+    # {.normalize_email}
+    #
+    # @return [String]
     def normalize_email
       self.email = self.class.normalize_email(email)
     end
 
+    # Always false. Override this method in your user model to allow for other
+    # forms of user authentication (username, Facebook, etc).
+    #
+    # @return [false]
     def email_optional?
       false
     end
 
+    # Always false. Override this method in your user model to allow for other
+    # forms of user authentication (username, Facebook, etc).
+    #
+    # @return [false]
     def password_optional?
       false
     end
 
+    # True if {#password_optional?} is true or if the user already has an
+    # {#encrypted_password} that is not changing.
+    #
+    # @return [Boolean]
     def skip_password_validation?
       password_optional? || (encrypted_password.present? && !password_changing)
     end
 
+    # Sets the {#confirmation_token} on the instance to a new value generated by
+    # {Token.new}. The change is not automatically persisted. If you would like
+    # to generate and save in a single method call, use {#forgot_password!}.
+    #
+    # @return [String] The new confirmation token
     def generate_confirmation_token
       self.confirmation_token = Clearance::Token.new
     end
 
+    # Sets the {#remember_token} on the instance to a new value generated by
+    # {Token.new}. The change is not automatically persisted. If you would like
+    # to generate and sace in a single method call, use
+    # {#reset_remember_token!}.
+    #
+    # @return [String] The new remember token
     def generate_remember_token
       self.remember_token = Clearance::Token.new
     end
+
+    private_constant :Callbacks, :ClassMethods, :Validations
   end
 end


### PR DESCRIPTION
Several areas of clearance, the user module being one, contain methods that
are marked as private in ruby but are actually part of the public API for
the gem. For instance the private methods in the User module are private so
that they aren't exposed publicly in the host application's user model, but
they are certainly available for use to developers.

For this reason, this change include changes to the yard options to allow
documentation of private methods. If a method in Clearance is truly
internal API then it should be marked with `@api private`. The yard options
will skip these.

Now that we're allowing yard to document private methods, we need to be
explicit about what we do not wish to be public api by tagging it. This
definitely increases the noise in documentation of private parts of library
code, but it's the only way I could find to allow us to document the methods
that have private visiblity but are actually public API.