### PR TITLE
Correct typo in example

### DIFF
--- a/lib/clearance/authentication.rb
+++ b/lib/clearance/authentication.rb
@@ -53,7 +53,7 @@ module Clearance
     # Your block will receive either a {SuccessStatus} or {FailureStatus}
     #
     #     sign_in(user) do |status|
-    #       if status.success
+    #       if status.success?
     #         # ...
     #       else
     #         # ...


### PR DESCRIPTION
The example for `Authentication#sign_in` contains a small typo,
indicating that Status object yielded to the method's block responds to
`success` when in fact it responds to the predicate method `success?`.