### PR TITLE
Flash message when require login after access denied

### DIFF
--- a/config/locales/clearance.en.yml
+++ b/config/locales/clearance.en.yml
@@ -12,6 +12,7 @@ en:
     failure_after_update: Password can't be blank.
     failure_when_forbidden: Please double check the URL or try submitting
       the form again.
+    failure_when_access_denied: Please, you need to login.
   helpers:
     label:
       password:

--- a/config/locales/clearance.en.yml
+++ b/config/locales/clearance.en.yml
@@ -12,7 +12,7 @@ en:
     failure_after_update: Password can't be blank.
     failure_when_forbidden: Please double check the URL or try submitting
       the form again.
-    failure_when_access_denied: Please, you need to login.
+    failure_when_not_signed_in: Please sign in to continue
   helpers:
     label:
       password:

--- a/lib/clearance/authorization.rb
+++ b/lib/clearance/authorization.rb
@@ -19,7 +19,7 @@ module Clearance
     #     end
     def require_login
       unless signed_in?
-        deny_access(I18n.t('flashes.failure_when_access_denied'))
+        deny_access(I18n.t("flashes.failure_when_not_signed_in"))
       end
     end
 

--- a/lib/clearance/authorization.rb
+++ b/lib/clearance/authorization.rb
@@ -19,7 +19,7 @@ module Clearance
     #     end
     def require_login
       unless signed_in?
-        deny_access
+        deny_access(I18n.t('flashes.failure_when_access_denied'))
       end
     end
 

--- a/spec/controllers/permissions_controller_spec.rb
+++ b/spec/controllers/permissions_controller_spec.rb
@@ -55,7 +55,7 @@ describe PermissionsController do
       expect(subject).to deny_access(redirect: sign_in_url)
     end
 
-    it 'denies access to show and display a flash message' do
+    it "denies access to show and display a flash message" do
       get :show
 
       expect(flash[:notice]).to match(/^Please, you need to login/)

--- a/spec/controllers/permissions_controller_spec.rb
+++ b/spec/controllers/permissions_controller_spec.rb
@@ -58,7 +58,7 @@ describe PermissionsController do
     it "denies access to show and display a flash message" do
       get :show
 
-      expect(flash[:notice]).to match(/^Please, you need to login/)
+      expect(flash[:notice]).to match(/^Please sign in to continue/)
     end
   end
 

--- a/spec/controllers/permissions_controller_spec.rb
+++ b/spec/controllers/permissions_controller_spec.rb
@@ -54,6 +54,12 @@ describe PermissionsController do
 
       expect(subject).to deny_access(redirect: sign_in_url)
     end
+
+    it 'denies access to show and display a flash message' do
+      get :show
+
+      expect(flash[:notice]).to match(/^Please, you need to login/)
+    end
   end
 
   context 'when remember_token is blank' do


### PR DESCRIPTION
I added a flash message in require_login method  (Authorization class). 
This message is displayed when a non-authenticated user is accessing a resource that needs an authenticated user.
I think it's helpful to add a message of what the user needs to do to access the resource.
This solves #562.