### PR TITLE
Clean up indentation of generated routes

### DIFF
--- a/lib/generators/clearance/routes/routes_generator.rb
+++ b/lib/generators/clearance/routes/routes_generator.rb
@@ -26,6 +26,21 @@ module Clearance
       def routes_file_path
         File.expand_path(find_in_source_paths('routes.rb'))
       end
+
+      def route(routing_code)
+        log :route, "all clearance routes"
+        sentinel = /\.routes\.draw do\s*\n/m
+
+        in_root do
+          inject_into_file(
+            "config/routes.rb",
+            routing_code,
+            after: sentinel,
+            verbose: false,
+            force: true,
+          )
+        end
+      end
     end
   end
 end

--- a/lib/generators/clearance/routes/templates/routes.rb
+++ b/lib/generators/clearance/routes/templates/routes.rb
@@ -1,12 +1,12 @@
-resources :passwords, controller: "clearance/passwords", only: [:create, :new]
-resource :session, controller: "clearance/sessions", only: [:create]
+  resources :passwords, controller: "clearance/passwords", only: [:create, :new]
+  resource :session, controller: "clearance/sessions", only: [:create]
 
-resources :users, controller: "clearance/users", only: [:create] do
-  resource :password,
-    controller: "clearance/passwords",
-    only: [:create, :edit, :update]
-end
+  resources :users, controller: "clearance/users", only: [:create] do
+    resource :password,
+      controller: "clearance/passwords",
+      only: [:create, :edit, :update]
+  end
 
-get "/sign_in" => "clearance/sessions#new", as: "sign_in"
-delete "/sign_out" => "clearance/sessions#destroy", as: "sign_out"
-get "/sign_up" => "clearance/users#new", as: "sign_up"
+  get "/sign_in" => "clearance/sessions#new", as: "sign_in"
+  delete "/sign_out" => "clearance/sessions#destroy", as: "sign_out"
+  get "/sign_up" => "clearance/users#new", as: "sign_up"


### PR DESCRIPTION
The `route` generator action provided by rails assumes a single line
route injection. The first line is automatically indented, but the
following lines are not.

I thought about injecting the routes one line at a time, but that
results in weird output from the generator because we format some long
lines in the routes to avoid going over 80 characters.

I decided to override the `route` action provided by default rails
generators to do exactly what we need. This also has the benefit of
cleaning up the output of the generator as well.