### PR TITLE
Correct indentation for existing user class

### DIFF
--- a/lib/generators/clearance/install/install_generator.rb
+++ b/lib/generators/clearance/install/install_generator.rb
@@ -23,7 +23,7 @@ module Clearance
         if File.exist? "app/models/user.rb"
           inject_into_file(
             "app/models/user.rb",
-            "include Clearance::User\n\n",
+            "  include Clearance::User\n\n",
             after: "class User < ActiveRecord::Base\n"
           )
         else


### PR DESCRIPTION
When injecting the `Clearance::User` include in a previously existing
`User` class, the indentation was incorrect.