### PR TITLE
Fix mailer delivery expectation

### DIFF
--- a/lib/generators/clearance/specs/templates/features/clearance/visitor_resets_password_spec.rb.tt
+++ b/lib/generators/clearance/specs/templates/features/clearance/visitor_resets_password_spec.rb.tt
@@ -47,7 +47,7 @@ feature "Visitor resets password" do
     message = ActionMailer::Base.deliveries.any? do |email|
       email.to == [recipient] &&
         email.subject =~ /#{subject}/i &&
-        email.html_part.body =~ /#{body}/
+        email.html_part.body =~ /#{body}/ &&
         email.text_part.body =~ /#{body}/
     end
 


### PR DESCRIPTION
3ca7a6b20a73f90b68fbfdb5a794d6caa1d941ef introduced a change in
`visitor_resets_password_spec.rb.tt` to break up the expectation on the
email's body into an `html_part` and `text_part`. The block that finds
the email however was only considering the match to the `text_part`
because it was not chained to the other conditions, so the subject and
html part were effectively ignored.

This commit chains all the conditions together to ensure they are
finding the right thing.

***

Note: I couldn't find anywhere where this code was being executed in the test suite, but I did verify that the change passed in my app, and that inverting the conditions of the first expression (i.e. by using `!~` instead of `=~`s) had no effect before, but did fail the test after. Hope that suffices!