### PR TITLE
Ignore the railsrc if present

### DIFF
--- a/spec/acceptance/clearance_installation_spec.rb
+++ b/spec/acceptance/clearance_installation_spec.rb
@@ -28,7 +28,8 @@ describe "Clearance Installation" do
        --skip-git \
        --skip-javascript \
        --skip-sprockets \
-       --skip-keeps"
+       --skip-keeps \
+       --no-rc"
 
     FileUtils.rm_f("public/index.html")
     FileUtils.rm_f("app/views/layouts/application.html.erb")


### PR DESCRIPTION
A railsrc may make unwanted configurations when generating the test app,
so this change adds the `--no-rc` flag which will ignore it.