### PR TITLE
add translation value used by the reset password mailer

### DIFF
--- a/app/mailers/clearance_mailer.rb
+++ b/app/mailers/clearance_mailer.rb
@@ -6,8 +6,7 @@ class ClearanceMailer < ActionMailer::Base
       to: @user.email,
       subject: I18n.t(
         :change_password,
-        scope: [:clearance, :models, :clearance_mailer],
-        default: "Change your password"
+        scope: [:clearance, :models, :clearance_mailer]
       )
     )
   end

--- a/config/locales/clearance.en.yml
+++ b/config/locales/clearance.en.yml
@@ -1,5 +1,10 @@
 ---
 en:
+  clearance:
+    models:
+      clearance_mailer:
+        change_password: Change your password
+
   clearance_mailer:
     change_password:
       closing: If you didn't request this, ignore this email. Your password has


### PR DESCRIPTION
The documentation suggests that you can alter the email subject of the reset password mailer inside the config/locales/clearance.en.yml file, however, there is no default value there.  It would probably be more user friendly if the default value existed inside the config/locales/clearance.en.yml file.