### PR TITLE
Make generated code follow the current style guide

### DIFF
--- a/lib/generators/clearance/install/templates/db/migrate/add_clearance_to_users.rb
+++ b/lib/generators/clearance/install/templates/db/migrate/add_clearance_to_users.rb
@@ -24,7 +24,7 @@ class AddClearanceToUsers < ActiveRecord::Migration
   def self.down
     change_table :users do |t|
 <% if config[:new_columns].any? -%>
-      t.remove <%= new_columns.keys.map { |column| ":#{column}" }.join(",") %>
+      t.remove <%= new_columns.keys.map { |column| ":#{column}" }.join(", ") %>
 <% end -%>
     end
   end


### PR DESCRIPTION
Since these migrations are generated, we want them to follow the current
style guide. So when opening a PR, there will be no violations reported
from [Hound].

[Hound]: https://houndci.com