### PR TITLE
Make create_users migration Rails 3.2 compatible

### DIFF
--- a/lib/generators/clearance/install/templates/db/migrate/create_users.rb
+++ b/lib/generators/clearance/install/templates/db/migrate/create_users.rb
@@ -6,8 +6,9 @@ class CreateUsers < ActiveRecord::Migration
       t.string :encrypted_password, limit: 128, null: false
       t.string :confirmation_token, limit: 128
       t.string :remember_token, limit: 128, null: false
-      t.index :email
-      t.index :remember_token
     end
+
+    add_index :users, :email
+    add_index :users, :remember_token
   end
 end


### PR DESCRIPTION
This reverts commit d080a5b2f1adff8fcb104e39b1b192b7c901d689. The
`index` method was introduced to `ActiveRecord::TableDefinition` in
Rails 4.0, but Clearance 1.x supports back to 3.2.

This should have been a test failure, but it seems our tests are not
executing in the environment we think they are. I'm working through that
issue in some changes to the test suite in PR #623.