### PR TITLE
Add raise: false to skip_before_filter

### DIFF
--- a/app/controllers/clearance/passwords_controller.rb
+++ b/app/controllers/clearance/passwords_controller.rb
@@ -1,8 +1,8 @@
 require 'active_support/deprecation'
 
 class Clearance::PasswordsController < Clearance::BaseController
-  skip_before_filter :require_login, only: [:create, :edit, :new, :update]
-  skip_before_filter :authorize, only: [:create, :edit, :new, :update]
+  skip_before_filter :require_login, only: [:create, :edit, :new, :update], raise: false
+  skip_before_filter :authorize, only: [:create, :edit, :new, :update], raise: false
   before_filter :ensure_existing_user, only: [:edit, :update]
 
   def create

--- a/app/controllers/clearance/sessions_controller.rb
+++ b/app/controllers/clearance/sessions_controller.rb
@@ -1,7 +1,7 @@
 class Clearance::SessionsController < Clearance::BaseController
   before_filter :redirect_signed_in_users, only: [:new]
-  skip_before_filter :require_login, only: [:create, :new, :destroy]
-  skip_before_filter :authorize, only: [:create, :new, :destroy]
+  skip_before_filter :require_login, only: [:create, :new, :destroy], raise: false
+  skip_before_filter :authorize, only: [:create, :new, :destroy], raise: false
 
   def create
     @user = authenticate(params)

--- a/app/controllers/clearance/users_controller.rb
+++ b/app/controllers/clearance/users_controller.rb
@@ -1,7 +1,7 @@
 class Clearance::UsersController < Clearance::BaseController
   before_filter :redirect_signed_in_users, only: [:create, :new]
-  skip_before_filter :require_login, only: [:create, :new]
-  skip_before_filter :authorize, only: [:create, :new]
+  skip_before_filter :require_login, only: [:create, :new], raise: false
+  skip_before_filter :authorize, only: [:create, :new], raise: false
 
   def new
     @user = user_from_params


### PR DESCRIPTION
This fixes issue #621 

In rails 5 if the filter has not been defined then
an error will be raised.

This change addresses the need by:

Adding raise: false to the passwords, sessions and
users controller