### PR TITLE
Remove use of `hide_action`

### DIFF
--- a/lib/clearance/authentication.rb
+++ b/lib/clearance/authentication.rb
@@ -4,7 +4,7 @@ module Clearance
 
     included do
       helper_method :current_user, :signed_in?, :signed_out?
-      hide_action(
+      private(
         :authenticate,
         :current_user,
         :current_user=,

--- a/lib/clearance/authorization.rb
+++ b/lib/clearance/authorization.rb
@@ -3,7 +3,7 @@ module Clearance
     extend ActiveSupport::Concern
 
     included do
-      hide_action :authorize, :deny_access, :require_login
+      private :authorize, :deny_access, :require_login
     end
 
     # Use as a `before_action` to require a user be signed in to proceed.

--- a/lib/clearance/testing/controller_helpers.rb
+++ b/lib/clearance/testing/controller_helpers.rb
@@ -29,7 +29,7 @@ module Clearance
       #
       # @return user
       def sign_in_as(user)
-        @controller.sign_in user
+        @request.env[:clearance].sign_in(user)
         user
       end
 
@@ -37,7 +37,7 @@ module Clearance
       #
       # @return [void]
       def sign_out
-        @controller.sign_out
+        @request.env[:clearance].sign_out
       end
     end
   end

--- a/lib/clearance/testing/deny_access_matcher.rb
+++ b/lib/clearance/testing/deny_access_matcher.rb
@@ -67,11 +67,15 @@ module Clearance
         private
 
         def denied_access_url
-          if @controller.signed_in?
+          if clearance_session.signed_in?
             '/'
           else
             @controller.sign_in_url
           end
+        end
+
+        def clearance_session
+          @controller.request.env[:clearance]
         end
 
         def flash_notice

--- a/spec/clearance/testing/controller_helpers_spec.rb
+++ b/spec/clearance/testing/controller_helpers_spec.rb
@@ -5,11 +5,11 @@ describe Clearance::Testing::ControllerHelpers do
     include Clearance::Testing::ControllerHelpers
 
     def initialize
-      @controller = Controller.new
-    end
-
-    class Controller
-      def sign_in(user); end
+      @request = Class.new do
+        def env
+          { clearance: Clearance::Session.new({}) }
+        end
+      end.new
     end
   end
 

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -45,7 +45,7 @@ describe Clearance::SessionsController do
       it { should redirect_to_url_after_create }
 
       it "sets the user in the clearance session" do
-        expect(controller.current_user).to eq @user
+        expect(request.env[:clearance].current_user).to eq @user
       end
 
       it "should not change the remember token" do
@@ -92,7 +92,7 @@ describe Clearance::SessionsController do
       end
 
       it "should unset the current user" do
-        expect(@controller.current_user).to be_nil
+        expect(request.env[:clearance].current_user).to be_nil
       end
     end
   end


### PR DESCRIPTION
We were previously relying on `hide_action` to hide clearance helpers,
which are public in their own modules, from appearing as routable
actions in the controllers they are mixed into.

`hide_action` has been removed from Rails. We can use `private` instead.