### PR TITLE
Don't rely on RSpec monkey patching for feature method

### DIFF
--- a/lib/generators/clearance/specs/templates/features/clearance/user_signs_out_spec.rb.tt
+++ b/lib/generators/clearance/specs/templates/features/clearance/user_signs_out_spec.rb.tt
@@ -1,7 +1,7 @@
 require "<%= @helper_file %>"
 require "support/features/clearance_helpers"
 
-feature "User signs out" do
+RSpec.feature "User signs out" do
   scenario "signs out" do
     sign_in
     sign_out

--- a/lib/generators/clearance/specs/templates/features/clearance/visitor_resets_password_spec.rb.tt
+++ b/lib/generators/clearance/specs/templates/features/clearance/visitor_resets_password_spec.rb.tt
@@ -1,7 +1,7 @@
 require "<%= @helper_file %>"
 require "support/features/clearance_helpers"
 
-feature "Visitor resets password" do
+RSpec.feature "Visitor resets password" do
   before { ActionMailer::Base.deliveries.clear }
 
   scenario "by navigating to the page" do

--- a/lib/generators/clearance/specs/templates/features/clearance/visitor_signs_in_spec.rb.tt
+++ b/lib/generators/clearance/specs/templates/features/clearance/visitor_signs_in_spec.rb.tt
@@ -1,7 +1,7 @@
 require "<%= @helper_file %>"
 require "support/features/clearance_helpers"
 
-feature "Visitor signs in" do
+RSpec.feature "Visitor signs in" do
   scenario "with valid email and password" do
     create_user "user@example.com", "password"
     sign_in_with "user@example.com", "password"

--- a/lib/generators/clearance/specs/templates/features/clearance/visitor_signs_up_spec.rb.tt
+++ b/lib/generators/clearance/specs/templates/features/clearance/visitor_signs_up_spec.rb.tt
@@ -1,7 +1,7 @@
 require "<%= @helper_file %>"
 require "support/features/clearance_helpers"
 
-feature "Visitor signs up" do
+RSpec.feature "Visitor signs up" do
   scenario "by navigating to the page" do
     visit sign_in_path
 

--- a/lib/generators/clearance/specs/templates/features/clearance/visitor_updates_password_spec.rb.tt
+++ b/lib/generators/clearance/specs/templates/features/clearance/visitor_updates_password_spec.rb.tt
@@ -1,7 +1,7 @@
 require "<%= @helper_file %>"
 require "support/features/clearance_helpers"
 
-feature "Visitor updates password" do
+RSpec.feature "Visitor updates password" do
   scenario "with valid password" do
     user = user_with_reset_password
     update_password user, "newpassword"


### PR DESCRIPTION
The default spec_helper's suggested config sets `disable_monkey_patching!`.
This causes specs generated by Clearance to fail out of the box. This change
should be backwards compatible with older versions of RSpec as well.

[This](https://github.com/rspec/rspec-core/pull/1647) PR added the
`disable_monkey_patching!` config as a suggested default.