### PR TITLE
Clean up Rails 5 deprecations

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -20,6 +20,7 @@ end
 if RUBY_VERSION >= "2.2.0"
   appraise "rails50" do
     gem "rails", "~> 5.0.0.beta1"
+    gem "rails-controller-testing"
     gem "rspec-rails", github: "rspec/rspec-rails"
     gem "rspec-support", github: "rspec/rspec-support"
     gem "rspec-core", github: "rspec/rspec-core"

--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ $ rails generate clearance:specs
 
 ### Controller Test Helpers
 
-To test controller actions that are protected by `before_filter :require_login`,
+To test controller actions that are protected by `before_action :require_login`,
 require Clearance's test helpers in your test suite.
 
 For `rspec`, add the following line to your `spec/rails_helper.rb` or

--- a/app/controllers/clearance/passwords_controller.rb
+++ b/app/controllers/clearance/passwords_controller.rb
@@ -1,13 +1,23 @@
 require 'active_support/deprecation'
 
 class Clearance::PasswordsController < Clearance::BaseController
-  skip_before_filter :require_login,
-    only: [:create, :edit, :new, :update],
-    raise: false
-  skip_before_filter :authorize,
-    only: [:create, :edit, :new, :update],
-    raise: false
-  before_filter :ensure_existing_user, only: [:edit, :update]
+  if respond_to?(:before_action)
+    skip_before_action :require_login,
+      only: [:create, :edit, :new, :update],
+      raise: false
+    skip_before_action :authorize,
+      only: [:create, :edit, :new, :update],
+      raise: false
+    before_action :ensure_existing_user, only: [:edit, :update]
+  else
+    skip_before_filter :require_login,
+      only: [:create, :edit, :new, :update],
+      raise: false
+    skip_before_filter :authorize,
+      only: [:create, :edit, :new, :update],
+      raise: false
+    before_filter :ensure_existing_user, only: [:edit, :update]
+  end
 
   def create
     if user = find_user_for_create

--- a/app/controllers/clearance/sessions_controller.rb
+++ b/app/controllers/clearance/sessions_controller.rb
@@ -1,11 +1,21 @@
 class Clearance::SessionsController < Clearance::BaseController
-  before_filter :redirect_signed_in_users, only: [:new]
-  skip_before_filter :require_login,
-    only: [:create, :new, :destroy],
-    raise: false
-  skip_before_filter :authorize,
-    only: [:create, :new, :destroy],
-    raise: false
+  if respond_to?(:before_action)
+    before_action :redirect_signed_in_users, only: [:new]
+    skip_before_action :require_login,
+      only: [:create, :new, :destroy],
+      raise: false
+    skip_before_action :authorize,
+      only: [:create, :new, :destroy],
+      raise: false
+  else
+    before_filter :redirect_signed_in_users, only: [:new]
+    skip_before_filter :require_login,
+      only: [:create, :new, :destroy],
+      raise: false
+    skip_before_filter :authorize,
+      only: [:create, :new, :destroy],
+      raise: false
+  end
 
   def create
     @user = authenticate(params)

--- a/app/controllers/clearance/users_controller.rb
+++ b/app/controllers/clearance/users_controller.rb
@@ -1,7 +1,13 @@
 class Clearance::UsersController < Clearance::BaseController
-  before_filter :redirect_signed_in_users, only: [:create, :new]
-  skip_before_filter :require_login, only: [:create, :new], raise: false
-  skip_before_filter :authorize, only: [:create, :new], raise: false
+  if respond_to?(:before_action)
+    before_action :redirect_signed_in_users, only: [:create, :new]
+    skip_before_action :require_login, only: [:create, :new], raise: false
+    skip_before_action :authorize, only: [:create, :new], raise: false
+  else
+    before_filter :redirect_signed_in_users, only: [:create, :new]
+    skip_before_filter :require_login, only: [:create, :new], raise: false
+    skip_before_filter :authorize, only: [:create, :new], raise: false
+  end
 
   def new
     @user = user_from_params

--- a/gemfiles/rails50.gemfile
+++ b/gemfiles/rails50.gemfile
@@ -14,6 +14,7 @@ gem "sqlite3", "~> 1.3"
 gem "timecop", "~> 0.6"
 gem "pry", :require => false
 gem "rails", "~> 5.0.0.beta1"
+gem "rails-controller-testing"
 gem "rspec-support", :github => "rspec/rspec-support"
 gem "rspec-core", :github => "rspec/rspec-core"
 gem "rspec-mocks", :github => "rspec/rspec-mocks"

--- a/lib/clearance/authorization.rb
+++ b/lib/clearance/authorization.rb
@@ -25,9 +25,9 @@ module Clearance
 
     # @deprecated use {#require_login}
     def authorize
-      warn "[DEPRECATION] Clearance's `authorize` before_filter is " +
+      warn "[DEPRECATION] Clearance's `authorize` before_action is " +
         "deprecated. Use `require_login` instead. Be sure to update any " +
-        "instances of `skip_before_filter :authorize` or " +
+        "instances of `skip_before_action :authorize` or " +
         "`skip_before_action :authorize` as well"
       require_login
     end

--- a/lib/generators/clearance/install/install_generator.rb
+++ b/lib/generators/clearance/install/install_generator.rb
@@ -101,7 +101,11 @@ module Clearance
       end
 
       def users_table_exists?
-        ActiveRecord::Base.connection.table_exists?(:users)
+        if ActiveRecord::Base.connection.respond_to?(:data_source_exists?)
+          ActiveRecord::Base.connection.data_source_exists?(:users)
+        else
+          ActiveRecord::Base.connection.table_exists?(:users)
+        end
       end
 
       def existing_users_columns

--- a/spec/app_templates/testapp/app/controllers/home_controller.rb
+++ b/spec/app_templates/testapp/app/controllers/home_controller.rb
@@ -1,5 +1,9 @@
 class HomeController < ApplicationController
   def show
-    render text: "", layout: "application"
+    if Rails::VERSION::MAJOR >= 5
+      render html: "", layout: "application"
+    else
+      render text: "", layout: "application"
+    end
   end
 end

--- a/spec/controllers/apis_controller_spec.rb
+++ b/spec/controllers/apis_controller_spec.rb
@@ -10,7 +10,7 @@ class ApisController < ActionController::Base
   end
 
   def show
-    render text: 'response'
+    head :ok
   end
 end
 

--- a/spec/controllers/apis_controller_spec.rb
+++ b/spec/controllers/apis_controller_spec.rb
@@ -3,7 +3,11 @@ require 'spec_helper'
 class ApisController < ActionController::Base
   include Clearance::Controller
 
-  before_filter :require_login
+  if respond_to?(:before_action)
+    before_action :require_login
+  else
+    before_filter :require_login
+  end
 
   def show
     render text: 'response'

--- a/spec/controllers/forgeries_controller_spec.rb
+++ b/spec/controllers/forgeries_controller_spec.rb
@@ -4,7 +4,12 @@ class ForgeriesController < ActionController::Base
   include Clearance::Controller
 
   protect_from_forgery
-  before_filter :require_login
+
+  if respond_to?(:before_action)
+    before_action :require_login
+  else
+    before_filter :require_login
+  end
 
   # This is off in test by default, but we need it for this test
   self.allow_forgery_protection = true

--- a/spec/controllers/permissions_controller_spec.rb
+++ b/spec/controllers/permissions_controller_spec.rb
@@ -3,7 +3,11 @@ require 'spec_helper'
 class PermissionsController < ActionController::Base
   include Clearance::Controller
 
-  before_filter :require_login, only: :show
+  if respond_to?(:before_action)
+    before_action :require_login, only: :show
+  else
+    before_filter :require_login, only: :show
+  end
 
   def new
     render text: 'New page'

--- a/spec/controllers/permissions_controller_spec.rb
+++ b/spec/controllers/permissions_controller_spec.rb
@@ -10,11 +10,11 @@ class PermissionsController < ActionController::Base
   end
 
   def new
-    render text: 'New page'
+    head :ok
   end
 
   def show
-    render text: 'Show page'
+    head :ok
   end
 end
 

--- a/spec/dummy/app/controllers/application_controller.rb
+++ b/spec/dummy/app/controllers/application_controller.rb
@@ -2,6 +2,10 @@ class ApplicationController < ActionController::Base
   include Clearance::Controller
 
   def show
-    render text: '', layout: 'application'
+    if Rails::VERSION::MAJOR >= 5
+      render html: "", layout: "application"
+    else
+      render text: "", layout: "application"
+    end
   end
 end

--- a/spec/generators/clearance/install/install_generator_spec.rb
+++ b/spec/generators/clearance/install/install_generator_spec.rb
@@ -61,9 +61,7 @@ describe Clearance::Generators::InstallGenerator, :generator do
     context "users table does not exist" do
       it "creates a migration to create the users table" do
         provide_existing_application_controller
-        allow(ActiveRecord::Base.connection).to receive(:table_exists?).
-          with(:users).
-          and_return(false)
+        table_does_not_exist(:users)
 
         run_generator
         migration = migration_file("db/migrate/create_users.rb")
@@ -113,6 +111,20 @@ describe Clearance::Generators::InstallGenerator, :generator do
         expect(migration).not_to contain("t.string :remember_token")
         expect(migration).not_to contain("add_index :users, :remember_token")
       end
+    end
+  end
+
+  def table_does_not_exist(name)
+    connection = ActiveRecord::Base.connection
+
+    if connection.respond_to?(:data_source_exists?)
+      allow(connection).to receive(:data_source_exists?).
+        with(name).
+        and_return(false)
+    else
+      allow(connection).to receive(:table_exists?).
+        with(name).
+        and_return(false)
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,6 +26,13 @@ RSpec.configure do |config|
   config.mock_with :rspec do |mocks|
     mocks.syntax = :expect
   end
+
+  if Rails::VERSION::MAJOR >= 5
+    require 'rails-controller-testing'
+    config.include Rails::Controller::Testing::TestProcess
+    config.include Rails::Controller::Testing::TemplateAssertions
+    config.include Rails::Controller::Testing::Integration
+  end
 end
 
 def restore_default_config

--- a/spec/support/http_method_shim.rb
+++ b/spec/support/http_method_shim.rb
@@ -1,0 +1,23 @@
+# Rails 5 deprecates calling HTTP action methods with positional arguments
+# in favor of keyword arguments. However, the keyword argument form is only
+# supported in Rails 5+. Since we support back to 3.1, we need some sort of shim
+# to avoid super noisy deprecations when running tests.
+module HTTPMethodShim
+  def get(path, params=nil, headers=nil)
+    super(path, params: params, headers: headers)
+  end
+
+  def put(path, params=nil, headers=nil)
+    super(path, params: params, headers: headers)
+  end
+
+  def post(path, params=nil, headers=nil)
+    super(path, params: params, headers: headers)
+  end
+end
+
+if Rails::VERSION::MAJOR >= 5
+  RSpec.configure do |config|
+    config.include HTTPMethodShim, type: :controller
+  end
+end


### PR DESCRIPTION
I believe these are all of the runtime deprecations we're getting under Rails
5. It's a bit hard to tell because there's also a lot of noise in the tests
from the decision to deprecate calling the HTTP verb methods in controller and
integration tests with positional arguments. That's "only" a deprecation we get
in our tests so we'll handle that separately.

Each of these fixes will remain a discrete commit with its own description. I'm
not thrilled with the `before_action` changes but this is going to be the last
minor version that supports Rails 3.x, so we can clean that up after release.