### PR TITLE
Use proper param name for overridden user model

### DIFF
--- a/app/controllers/clearance/users_controller.rb
+++ b/app/controllers/clearance/users_controller.rb
@@ -56,6 +56,6 @@ class Clearance::UsersController < Clearance::BaseController
   end
 
   def user_params
-    params[:user] || Hash.new
+    params[Clearance.configuration.user_parameter] || Hash.new
   end
 end

--- a/lib/clearance/configuration.rb
+++ b/lib/clearance/configuration.rb
@@ -121,12 +121,20 @@ module Clearance
       end
     end
 
+    # The name of user parameter for the configured user model.
+    # This is derived from the `model_name` of the `user_model` setting.
+    # In the default configuration, this is `user`.
+    # @return [Symbol]
+    def user_parameter
+      user_model.model_name.singular.to_sym
+    end
+
     # The name of foreign key parameter for the configured user model.
     # This is derived from the `model_name` of the `user_model` setting.
     # In the default configuration, this is `user_id`.
     # @return [Symbol]
     def user_id_parameter
-      "#{user_model.model_name.singular}_id".to_sym
+      "#{user_parameter}_id".to_sym
     end
 
     # @return [Boolean] are Clearance's built-in routes enabled?

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -143,6 +143,15 @@ describe Clearance::Configuration do
     end
   end
 
+  describe "#user_parameter" do
+    it "returns the parameter key to use based on the user_model" do
+      Account = Class.new(ActiveRecord::Base)
+      Clearance.configure { |config| config.user_model = Account }
+
+      expect(Clearance.configuration.user_parameter).to eq :account
+    end
+  end
+
   describe '#user_id_parameter' do
     it 'returns the parameter key to use based on the user_model' do
       CustomUser = Class.new(ActiveRecord::Base)


### PR DESCRIPTION
The users controller was hard-coded to grab parameters from
`params[:user]`, but if you have changed your user model the key will be
something other than `:user`. We now get this key from configuration,
which derives it from the model name.