### PR TITLE
Test against Rails 5 master

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -19,7 +19,7 @@ end
 
 if RUBY_VERSION >= "2.2.0"
   appraise "rails50" do
-    gem "rails", "~> 5.0.0.beta1"
+    gem "rails", git: "https://github.com/rails/rails"
     gem "rails-controller-testing"
     gem "rspec-rails", github: "rspec/rspec-rails"
     gem "rspec-support", github: "rspec/rspec-support"

--- a/gemfiles/rails50.gemfile
+++ b/gemfiles/rails50.gemfile
@@ -13,7 +13,7 @@ gem "shoulda-matchers", "~> 2.8"
 gem "sqlite3", "~> 1.3"
 gem "timecop", "~> 0.6"
 gem "pry", :require => false
-gem "rails", "~> 5.0.0.beta1"
+gem "rails", :git => "https://github.com/rails/rails"
 gem "rails-controller-testing"
 gem "rspec-support", :github => "rspec/rspec-support"
 gem "rspec-core", :github => "rspec/rspec-core"

--- a/spec/dummy/application.rb
+++ b/spec/dummy/application.rb
@@ -37,6 +37,10 @@ module Dummy
       config.paths.add "config/routes", with: "#{APP_ROOT}/config/routes.rb"
     end
 
+    if config.respond_to?(:active_job)
+      config.active_job.queue_adapter = :inline
+    end
+
     def require_environment!
       initialize!
     end


### PR DESCRIPTION
Master includes a fix for https://github.com/rails/rails/issues/23645,
which is not yet included in a beta release.

When updating to master, I also had to explicitly set the ActiveJob
queue adapter to `inline` in tests, as it now defaults to `async`.

With these changes, the non-acceptance test suite is now green and has
no deprecations. Next up - the acceptance tests.