### PR TITLE
Use versioned migrations when possible

### DIFF
--- a/lib/generators/clearance/install/install_generator.rb
+++ b/lib/generators/clearance/install/install_generator.rb
@@ -61,7 +61,7 @@ module Clearance
           migration_template(
             "db/migrate/#{migration_name}",
             "db/migrate/#{migration_name}",
-            config
+            config.merge(migration_version: migration_version),
           )
         end
       end
@@ -119,6 +119,12 @@ module Clearance
       # for generating a timestamp when using `create_migration`
       def self.next_migration_number(dir)
         ActiveRecord::Generators::Base.next_migration_number(dir)
+      end
+
+      def migration_version
+        if Rails.version >= "5.0.0"
+          "[#{Rails::VERSION::MAJOR}.#{Rails::VERSION::MINOR}]"
+        end
       end
     end
   end

--- a/lib/generators/clearance/install/templates/db/migrate/add_clearance_to_users.rb
+++ b/lib/generators/clearance/install/templates/db/migrate/add_clearance_to_users.rb
@@ -1,4 +1,4 @@
-class AddClearanceToUsers < ActiveRecord::Migration
+class AddClearanceToUsers < ActiveRecord::Migration<%= migration_version %>
   def self.up
     change_table :users do |t|
 <% config[:new_columns].values.each do |column| -%>

--- a/lib/generators/clearance/install/templates/db/migrate/create_users.rb
+++ b/lib/generators/clearance/install/templates/db/migrate/create_users.rb
@@ -1,4 +1,4 @@
-class CreateUsers < ActiveRecord::Migration
+class CreateUsers < ActiveRecord::Migration<%= migration_version %>
   def change
     create_table :users do |t|
       t.timestamps null: false


### PR DESCRIPTION
Rails 5 deprecates inheriting directly from `ActiveRecord::Migration` in
favor of inheriting from `ActiveRecord::Migration[5.0]` where `5.0` is
the `major.minor` version of Rails that the migration was originally
written to support.

If we detect we are using a version of rails that supports this
nomenclature then we pass the current `major.minor` version to use.