### PR TITLE
Always use inline adapter in feature specs

### DIFF
--- a/app/controllers/clearance/passwords_controller.rb
+++ b/app/controllers/clearance/passwords_controller.rb
@@ -53,7 +53,7 @@ class Clearance::PasswordsController < Clearance::BaseController
   def deliver_email(user)
     mail = ::ClearanceMailer.change_password(user)
 
-    if Gem::Version.new(Rails::VERSION::STRING) >= Gem::Version.new("4.2.0")
+    if mail.respond_to?(:deliver_later)
       mail.deliver_later
     else
       mail.deliver

--- a/lib/generators/clearance/specs/templates/features/clearance/visitor_resets_password_spec.rb.tt
+++ b/lib/generators/clearance/specs/templates/features/clearance/visitor_resets_password_spec.rb.tt
@@ -3,6 +3,15 @@ require "support/features/clearance_helpers"
 
 RSpec.feature "Visitor resets password" do
   before { ActionMailer::Base.deliveries.clear }
+<% if defined?(ActiveJob) -%>
+
+  around do |example|
+    original_adapter = ActiveJob::Base.queue_adapter
+    ActiveJob::Base.queue_adapter = :inline
+    example.run
+    ActiveJob::Base.queue_adapter = original_adapter
+  end
+<% end -%>
 
   scenario "by navigating to the page" do
     visit sign_in_path


### PR DESCRIPTION
Rails 5 defaults the ActiveJob adapter to `async` which makes it
difficult to test the password reset feature in a manner that supports
Rails 4.2 and 5.0 (and older versions as well, of course).

The simplest fix, for now, is to use the inline adapter in our tests so
we can observe the side effects we care about.