### PR TITLE
Call `find_by` instead of `where` and `first

### DIFF
--- a/lib/clearance/session.rb
+++ b/lib/clearance/session.rb
@@ -131,7 +131,7 @@ module Clearance
 
     # @api private
     def user_from_remember_token(token)
-      Clearance.configuration.user_model.where(remember_token: token).first
+      Clearance.configuration.user_model.find_by(remember_token: token)
     end
 
     # @api private


### PR DESCRIPTION
Why:

* There is no need to call `where` if we are going to call `first` right
  after it.

This change addresses the need by:

* Using the more intent revealing `find_by`