### PR TITLE
Add argon2 password strategy + spec

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     clearance (1.13.0)
+      argon2
       bcrypt
       email_validator (~> 1.4)
       rails (>= 3.1)
@@ -54,7 +55,10 @@ GEM
       rake
       thor (>= 0.14.0)
     arel (6.0.3)
-    bcrypt (3.1.10)
+    argon2 (0.1.4)
+      ffi (~> 1.9)
+      ffi-compiler (~> 0.1)
+    bcrypt (3.1.11)
     builder (3.2.2)
     capybara (2.6.2)
       addressable
@@ -75,6 +79,10 @@ GEM
     factory_girl_rails (4.5.0)
       factory_girl (~> 4.5.0)
       railties (>= 3.0.0)
+    ffi (1.9.10)
+    ffi-compiler (0.1.3)
+      ffi (>= 1.0.0)
+      rake
     globalid (0.3.6)
       activesupport (>= 4.1.0)
     i18n (0.7.0)
@@ -175,4 +183,4 @@ DEPENDENCIES
   timecop (~> 0.6)
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/clearance.gemspec
+++ b/clearance.gemspec
@@ -4,6 +4,7 @@ require 'date'
 
 Gem::Specification.new do |s|
   s.add_dependency 'bcrypt'
+  s.add_dependency 'argon2'
   s.add_dependency 'email_validator', '~> 1.4'
   s.add_dependency 'rails', '>= 3.1'
   s.authors = [

--- a/lib/clearance/password_strategies.rb
+++ b/lib/clearance/password_strategies.rb
@@ -18,5 +18,6 @@ module Clearance
       'clearance/password_strategies/bcrypt_migration_from_sha1'
     autoload :Blowfish, 'clearance/password_strategies/blowfish'
     autoload :SHA1, 'clearance/password_strategies/sha1'
+    autoload :Argon2, 'clearance/password_strategies/argon2'
   end
 end

--- a/lib/clearance/password_strategies/argon2.rb
+++ b/lib/clearance/password_strategies/argon2.rb
@@ -24,15 +24,12 @@ module Clearance
       def encrypt(password)
         t_cost, m_cost = costs
         argon = ::Argon2::Password.new(t_cost: t_cost, m_cost: m_cost)
-
-        binding.pry # ::Argon2::Password.create("password") (NoMethodError)
-
         argon.create(password)
       end
 
       # @api private
       def costs
-        test_environment? ? [1, 1] : [2, 16]
+        test_environment? ? [1, 4] : [2, 16]
       end
 
       # @api private

--- a/lib/clearance/password_strategies/argon2.rb
+++ b/lib/clearance/password_strategies/argon2.rb
@@ -1,0 +1,44 @@
+module Clearance
+  module PasswordStrategies
+    module Argon2
+      require 'argon2'
+      require 'pry'
+
+      def authenticated?(password)
+        if encrypted_password.present?
+          ::Argon2::Password.verify_password(password, encrypted_password)
+        end
+      end
+
+      def password=(new_password)
+        @password = new_password
+
+        if new_password.present?
+          self.encrypted_password = encrypt(new_password)
+        end
+      end
+
+      private
+
+      # @api private
+      def encrypt(password)
+        t_cost, m_cost = costs
+        argon = ::Argon2::Password.new(t_cost: t_cost, m_cost: m_cost)
+
+        binding.pry # ::Argon2::Password.create("password") (NoMethodError)
+
+        argon.create(password)
+      end
+
+      # @api private
+      def costs
+        test_environment? ? [1, 1] : [2, 16]
+      end
+
+      # @api private
+      def test_environment?
+        defined?(::Rails) && ::Rails.env.test?
+      end
+    end
+  end
+end

--- a/spec/password_strategies/argon2_spec.rb
+++ b/spec/password_strategies/argon2_spec.rb
@@ -1,0 +1,85 @@
+require "spec_helper"
+include FakeModelWithPasswordStrategy
+
+describe Clearance::PasswordStrategies::Argon2 do
+  describe "#password=" do
+    it "encrypts the password into encrypted_password" do
+      stub_argon2_password
+      
+      model_instance = fake_model_with_argon2_strategy
+
+      model_instance.password = password
+
+      expect(model_instance.encrypted_password).to eq encrypted_password
+    end
+
+    it "encrypts with Argon2 using default cost in non test environments" do
+      stub_argon2_password
+      model_instance = fake_model_with_argon2_strategy
+
+      allow(Rails).to receive(:env).
+        and_return(ActiveSupport::StringInquirer.new("production"))
+
+      model_instance.password = password
+
+      expect(Argon2::Password).to have_received(:create).with(
+        password,
+        t_cost: 2,
+        m_cost: 16
+      )
+    end
+
+    it "encrypts with Argon2 using minimum cost in test environment" do
+      stub_argon2_password
+      model_instance = fake_model_with_argon2_strategy
+
+      model_instance.password = password
+
+      expect(Argon2::Password).to have_received(:create).with(
+        password,
+        t_cost: 1,
+        m_cost: 1
+      )
+    end
+
+    def stub_argon2_password
+      allow(Argon2::Password).to receive(:create).and_return(encrypted_password)
+    end
+
+    def encrypted_password
+      @encrypted_password ||= double("encrypted password")
+    end
+  end
+
+  describe "#authenticated?" do
+    context "given a password" do
+      it "is authenticated with Argon2" do
+        model_instance = fake_model_with_argon2_strategy
+
+        model_instance.password = password
+
+        expect(model_instance).to be_authenticated(password)
+      end
+    end
+
+    context "given no password" do
+      it "is not authenticated" do
+        model_instance = fake_model_with_argon2_strategy
+
+        password = nil
+
+        expect(model_instance).not_to be_authenticated(password)
+      end
+    end
+  end
+
+  def fake_model_with_argon2_strategy
+    @model_instance ||= fake_model_with_password_strategy(
+      Clearance::PasswordStrategies::Argon2
+    )
+  end
+
+  def password
+    "password"
+  end
+end

--- a/spec/password_strategies/argon2_spec.rb
+++ b/spec/password_strategies/argon2_spec.rb
@@ -19,21 +19,24 @@ describe Clearance::PasswordStrategies::Argon2 do
       allow(Rails).to receive(:env).
         and_return(ActiveSupport::StringInquirer.new("production"))
 
-      model_instance.password = password
+      expect(Argon2::Password).to receive(:new).with(t_cost: 2, m_cost: 16).
+        and_return(Argon2::Password.new(t_cost: 2, m_cost: 16))
 
-      expect(Argon2::Password).to receive(:new).with(t_cost: 2, m_cost: 16)
+      model_instance.password = password
     end
 
     it "encrypts with Argon2 using minimum cost in test environment" do
       model_instance = fake_model_with_argon2_strategy
 
-      model_instance.password = password
+      expect(Argon2::Password).to receive(:new).with(t_cost: 1, m_cost: 4).
+        and_return(Argon2::Password.new(t_cost: 1, m_cost: 4))
 
-      expect(Argon2::Password).to receive(:new).with(t_cost: 1, m_cost: 4)
+      model_instance.password = password
     end
 
     def stub_argon2_password
-      allow_any_instance_of(Argon2::Password).to receive(:create).and_return(encrypted_password)
+      allow_any_instance_of(Argon2::Password).to receive(:create).
+        and_return(encrypted_password)
     end
 
     def encrypted_password

--- a/spec/password_strategies/argon2_spec.rb
+++ b/spec/password_strategies/argon2_spec.rb
@@ -5,7 +5,7 @@ describe Clearance::PasswordStrategies::Argon2 do
   describe "#password=" do
     it "encrypts the password into encrypted_password" do
       stub_argon2_password
-      
+
       model_instance = fake_model_with_argon2_strategy
 
       model_instance.password = password
@@ -14,7 +14,7 @@ describe Clearance::PasswordStrategies::Argon2 do
     end
 
     it "encrypts with Argon2 using default cost in non test environments" do
-      stub_argon2_password
+      stub_argon2_cost(t_cost: 4, m_cost: 16)
       model_instance = fake_model_with_argon2_strategy
 
       allow(Rails).to receive(:env).
@@ -22,28 +22,28 @@ describe Clearance::PasswordStrategies::Argon2 do
 
       model_instance.password = password
 
-      expect(Argon2::Password).to have_received(:create).with(
-        password,
-        t_cost: 2,
-        m_cost: 16
-      )
+      expect(model_instance.encrypted_password).to eq('proper cost')
     end
 
     it "encrypts with Argon2 using minimum cost in test environment" do
-      stub_argon2_password
+      stub_argon2_cost(t_cost: 1, m_cost: 4)
       model_instance = fake_model_with_argon2_strategy
 
       model_instance.password = password
 
-      expect(Argon2::Password).to have_received(:create).with(
-        password,
-        t_cost: 1,
-        m_cost: 1
-      )
+      expect(model_instance.encrypted_password).to eq('proper cost')
     end
 
     def stub_argon2_password
-      allow(Argon2::Password).to receive(:create).and_return(encrypted_password)
+      allow_any_instance_of(Argon2::Password).to receive(:create).and_return(encrypted_password)
+    end
+
+    def stub_argon2_cost(t_cost:, m_cost:)
+      allow_any_instance_of(Argon2::Password).to receive(:create).with(
+        password,
+        t_cost: t_cost,
+        m_cost: m_cost
+      ).and_return('proper cost')
     end
 
     def encrypted_password

--- a/spec/password_strategies/argon2_spec.rb
+++ b/spec/password_strategies/argon2_spec.rb
@@ -14,7 +14,6 @@ describe Clearance::PasswordStrategies::Argon2 do
     end
 
     it "encrypts with Argon2 using default cost in non test environments" do
-      stub_argon2_cost(t_cost: 4, m_cost: 16)
       model_instance = fake_model_with_argon2_strategy
 
       allow(Rails).to receive(:env).
@@ -22,28 +21,19 @@ describe Clearance::PasswordStrategies::Argon2 do
 
       model_instance.password = password
 
-      expect(model_instance.encrypted_password).to eq('proper cost')
+      expect(Argon2::Password).to receive(:new).with(t_cost: 2, m_cost: 16)
     end
 
     it "encrypts with Argon2 using minimum cost in test environment" do
-      stub_argon2_cost(t_cost: 1, m_cost: 4)
       model_instance = fake_model_with_argon2_strategy
 
       model_instance.password = password
 
-      expect(model_instance.encrypted_password).to eq('proper cost')
+      expect(Argon2::Password).to receive(:new).with(t_cost: 1, m_cost: 4)
     end
 
     def stub_argon2_password
       allow_any_instance_of(Argon2::Password).to receive(:create).and_return(encrypted_password)
-    end
-
-    def stub_argon2_cost(t_cost:, m_cost:)
-      allow_any_instance_of(Argon2::Password).to receive(:create).with(
-        password,
-        t_cost: t_cost,
-        m_cost: m_cost
-      ).and_return('proper cost')
     end
 
     def encrypted_password


### PR DESCRIPTION
I wanted to add argon2 strategy for a project I'm using.

I'm up against a hiccup though, `Argon2::Password.create("password")` gives me: `NoMethodError: undefined method `create' for Argon2::Password:Class`.

Using [ruby-argon2](https://github.com/technion/ruby-argon2). 

I'm still digging in, would love another set of eyes.

EDIT: See the contributing guide, fixing the spec.

EDIT 2: Done!