### PR TITLE
Allow Clearance::BackDoor to take a block

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,20 @@ Usage:
 visit root_path(as: user)
 ```
 
+Additionally, if `User#to_param` is overridden, you can pass a block in
+order to override the default behavior:
+
+```ruby
+# config/environments/test.rb
+MyRailsApp::Application.configure do
+  # ...
+  config.middleware.use Clearance::BackDoor do |username|
+    Clearance.configuration.user_model.find_by(username: username)
+  end
+  # ...
+end
+```
+
 ### Ready Made Feature Specs
 
 If you're using RSpec, you can generate feature specs to help prevent

--- a/lib/clearance/back_door.rb
+++ b/lib/clearance/back_door.rb
@@ -1,6 +1,7 @@
 module Clearance
   # Middleware which allows signing in by passing as=USER_ID in a query
-  # parameter.
+  # parameter. If `User#to_param` is overriden you may pass a block to
+  # override the default user lookup behaviour
   #
   # Designed to eliminate time in integration tests wasted by visiting and
   # submitting the sign in form.
@@ -14,12 +15,24 @@ module Clearance
   #     # ...
   #   end
   #
+  #   # or if `User#to_param` is overridden (to `username` for example):
+  #
+  #   # config/environments/test.rb
+  #   MyRailsApp::Application.configure do
+  #     # ...
+  #     config.middleware.use Clearance::BackDoor do |username|
+  #       User.find_by(username: username)
+  #     end
+  #     # ...
+  #   end
+  #
   # Usage:
   #
   #   visit new_feedback_path(as: user)
   class BackDoor
-    def initialize(app)
+    def initialize(app, &block)
       @app = app
+      @block = block
     end
 
     def call(env)
@@ -32,11 +45,20 @@ module Clearance
     # @api private
     def sign_in_through_the_back_door(env)
       params = Rack::Utils.parse_query(env['QUERY_STRING'])
-      user_id = params['as']
+      user_param = params['as']
 
-      if user_id.present?
-        user = Clearance.configuration.user_model.find(user_id)
+      if user_param.present?
+        user = find_user(user_param)
         env[:clearance].sign_in(user)
+      end
+    end
+
+    # @api private
+    def find_user(user_param)
+      if @block
+        @block.call(user_param)
+      else
+        Clearance.configuration.user_model.find(user_param)
       end
     end
   end


### PR DESCRIPTION
If `User#to_param` is overriden the `Clearance::BackDoor` will fail
because it only looks the user up by id. By passing a block, this
functionality can be replaced to be more flexible. For instance, with a
User model that looks like:

    class User < ActiveRecord::Base
      def to_param
        username
      end
    end

You can specific the following backdoor in
`config/environments/test.rb`:

    config.middleware.use Clearance::BackDoor do |username|
      Clearance.configuration.user_model.find_by(username: username)
    end