### PR TITLE
Remove html in text version of change password

### DIFF
--- a/app/views/clearance_mailer/change_password.text.erb
+++ b/app/views/clearance_mailer/change_password.text.erb
@@ -1,4 +1,4 @@
-<%= t(".opening") %></p>
+<%= t(".opening") %>
 
 <%= edit_user_password_url(@user, token: @user.confirmation_token.html_safe) %>
 


### PR DESCRIPTION
closing p tag present in text version of the change password email by
default.

I know most people change this quickly, but when sending tests to show what the default was with a copywriter. My email client alerted me that there was html in my text version, and thought that was spammy.