### PR TITLE
Add Defer Sign In Password Check feature

### DIFF
--- a/lib/clearance/configuration.rb
+++ b/lib/clearance/configuration.rb
@@ -85,6 +85,20 @@ module Clearance
     # @return [ActiveRecord::Base]
     attr_accessor :user_model
 
+    # Controls whether user password checks should be deferred to happen at the
+    # sign in guard stack. This feature enables a DeferredSignInUser object to
+    # enter within sign in guards, regardless if the user is authenticated or
+    # not.  Clearance's default behavior is to represent an unauthenticated
+    # user as nil, and this is undesirable if we need sign in guards to work
+    # with existing but unauthenticated user objects.
+    #
+    # DeferredSignInUser wraps a user object and can be used as such, and its
+    # present? method returns true only if the user is present AND password is
+    # correct.
+    #
+    # @return [Boolean]
+    attr_accessor :defer_sign_in_password_check
+
     def initialize
       @allow_sign_up = true
       @cookie_expiration = ->(cookies) { 1.year.from_now.utc }
@@ -97,6 +111,7 @@ module Clearance
       @routes = true
       @secure_cookie = false
       @sign_in_guards = []
+      @defer_sign_in_password_check = false
     end
 
     def user_model
@@ -140,6 +155,12 @@ module Clearance
     # @return [Boolean] are Clearance's built-in routes enabled?
     def routes_enabled?
       @routes
+    end
+
+    # Is the defer sign in password check feature enabled?
+    # @return [Boolean]
+    def defer_sign_in_password_check?
+      @defer_sign_in_password_check
     end
 
     # Reloads the clearance user model class.

--- a/lib/clearance/deferred_sign_in_user.rb
+++ b/lib/clearance/deferred_sign_in_user.rb
@@ -34,6 +34,14 @@ module Clearance
       __getobj__.nil?
     end
 
+    # Returns whether this is a deferred_sign_in_user, which it is. Can be used
+    # polymorphically with a regular user object.
+    #
+    # @return [Boolean]
+    def deferred_sign_in_user?
+      true
+    end
+
     private
 
     # @api private

--- a/lib/clearance/deferred_sign_in_user.rb
+++ b/lib/clearance/deferred_sign_in_user.rb
@@ -1,0 +1,46 @@
+module Clearance
+  class DeferredSignInUser < SimpleDelegator
+    def initialize(user, password)
+      @password = password
+      super user
+    end
+
+    # This method overrides ActiveSupport's present? method, and only returns
+    # true if the delegated user is present AND signed in. It has special
+    # domain meaning and allows Clearance::Session#signed_in? to work
+    # transparently with the defer_sign_in_password_check feature.
+    #
+    # @return [Boolean]
+    def present?
+      __getobj__.present? && signed_in?
+    end
+
+    # This is the opposite of our custom present? implementation.
+    #
+    # @return [Boolean]
+    def blank?
+      !present?
+    end
+
+    # This method overrides Kernel#nil? and only returns true if the delegated
+    # user is nil.
+    #
+    # It is part of the defer_sign_in_password_check feature, and should be
+    # used by client code to evaluate whether the delegated user is nil, which
+    # probably means the user does not exist in the database.
+    #
+    # @return [Boolean]
+    def nil?
+      __getobj__.nil?
+    end
+
+    private
+
+    # @api private
+    def signed_in?
+      return @signed_in unless @signed_in.nil?
+
+      @signed_in = authenticated?(@password)
+    end
+  end
+end

--- a/lib/clearance/deferred_sign_in_user.rb
+++ b/lib/clearance/deferred_sign_in_user.rb
@@ -1,3 +1,5 @@
+require "delegate"
+
 module Clearance
   class DeferredSignInUser < SimpleDelegator
     def initialize(user, password)

--- a/lib/clearance/user.rb
+++ b/lib/clearance/user.rb
@@ -214,6 +214,18 @@ module Clearance
       save
     end
 
+    # Returns whether this is a deferred_sign_in_user, which is not in this
+    # case.
+    #
+    # DeferredSignInUser objects are augmented wrappers to user objects. This
+    # method was implemented here in order to comply with a polymorphic
+    # contract.
+    #
+    # @return [Boolean]
+    def deferred_sign_in_user?
+      false
+    end
+
     private
 
     # Sets the email on this instance to the value returned by

--- a/lib/clearance/user.rb
+++ b/lib/clearance/user.rb
@@ -1,7 +1,7 @@
 require 'digest/sha1'
 require 'email_validator'
 require 'clearance/token'
-require 'clearance/deferred_sign_in_user'
+require "clearance/deferred_sign_in_user"
 
 module Clearance
   # Required to be included in your configued user class, which is `User` by

--- a/spec/clearance/session_spec.rb
+++ b/spec/clearance/session_spec.rb
@@ -52,7 +52,7 @@ describe Clearance::Session do
       expect(session.current_user).to eq user
     end
 
-    it 'is signed_in when user is present' do
+    it "is signed_in when user is present" do
       user = double(present?: true, remember_token: "foo")
 
       session.sign_in(user)
@@ -60,7 +60,7 @@ describe Clearance::Session do
       expect(session).to be_signed_in
     end
 
-    it 'is not signed_in when user is not present' do
+    it "is not signed_in when user is not present" do
       user = double(present?: false, remember_token: "foo")
 
       session.sign_in(user)

--- a/spec/clearance/session_spec.rb
+++ b/spec/clearance/session_spec.rb
@@ -52,6 +52,22 @@ describe Clearance::Session do
       expect(session.current_user).to eq user
     end
 
+    it 'is signed_in when user is present' do
+      user = double(present?: true, remember_token: "foo")
+
+      session.sign_in(user)
+
+      expect(session).to be_signed_in
+    end
+
+    it 'is not signed_in when user is not present' do
+      user = double(present?: false, remember_token: "foo")
+
+      session.sign_in(user)
+
+      expect(session).to_not be_signed_in
+    end
+
     context 'with a block' do
       it 'passes the success status to the block when sign in succeeds' do
         success_status = stub_status(Clearance::SuccessStatus, true)

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -186,4 +186,27 @@ describe Clearance::Configuration do
       expect(Clearance.configuration.reload_user_model).to be_nil
     end
   end
+
+  context "when defer_sign_in_password_check is set to true" do
+    before do
+      Clearance.configure do |config|
+        config.defer_sign_in_password_check = true
+      end
+    end
+
+    it "returns true" do
+      expect(Clearance.configuration.defer_sign_in_password_check).to eq true
+    end
+  end
+
+  context "when defer_sign_in_password_check is not specified" do
+    before do
+      Clearance.configure do |config|
+      end
+    end
+
+    it "defaults to false" do
+      expect(Clearance.configuration.defer_sign_in_password_check).to eq false
+    end
+  end
 end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -65,6 +65,18 @@ describe Clearance::SessionsController do
         should redirect_to(@return_url)
       end
     end
+
+    it "uses User#authenticate to perform the authentication" do
+      user = build(:user)
+      allow(User).to receive(:authenticate).
+        with(user.email, user.password).
+        once.
+        and_return(user)
+
+      post :create, session: { email: user.email, password: user.password }
+
+      expect(request.env[:clearance].current_user).to eq user
+    end
   end
 
   describe "on DELETE to #destroy" do

--- a/spec/deferred_sign_in_user_spec.rb
+++ b/spec/deferred_sign_in_user_spec.rb
@@ -6,7 +6,7 @@ describe Clearance::DeferredSignInUser do
     it "returns true" do
       deferred_sign_in_user = Clearance::DeferredSignInUser.new(
         nil,
-        "password"
+        "password",
       )
 
       expect(deferred_sign_in_user).to be_deferred_sign_in_user
@@ -18,7 +18,7 @@ describe Clearance::DeferredSignInUser do
       user = stub_user(authenticated: true, password: "password")
       deferred_sign_in_user = Clearance::DeferredSignInUser.new(
         user,
-        "password"
+        "password",
       )
 
       expect(deferred_sign_in_user).to be_present
@@ -32,7 +32,7 @@ describe Clearance::DeferredSignInUser do
       user = stub_user(authenticated: false, password: "password")
       deferred_sign_in_user = Clearance::DeferredSignInUser.new(
         user,
-        "password"
+        "password",
       )
 
       expect(deferred_sign_in_user).to_not be_present

--- a/spec/deferred_sign_in_user_spec.rb
+++ b/spec/deferred_sign_in_user_spec.rb
@@ -1,0 +1,57 @@
+require "spec_helper"
+
+describe Clearance::DeferredSignInUser do
+  context "when an underlying user is present and authenticated" do
+    it "is present, not blank and not nil" do
+      user = stub_user(authenticated: true, password: "password")
+      deferred_sign_in_user = Clearance::DeferredSignInUser.new(
+        user,
+        "password"
+      )
+
+      expect(deferred_sign_in_user).to be_present
+      expect(deferred_sign_in_user).to_not be_blank
+      expect(deferred_sign_in_user).to_not be_nil
+    end
+  end
+
+  context "when an underlying user is present and NOT authenticated" do
+    it "is not present, is blank and is not nil" do
+      user = stub_user(authenticated: false, password: "password")
+      deferred_sign_in_user = Clearance::DeferredSignInUser.new(
+        user,
+        "password"
+      )
+
+      expect(deferred_sign_in_user).to_not be_present
+      expect(deferred_sign_in_user).to be_blank
+      expect(deferred_sign_in_user).to_not be_nil
+    end
+  end
+
+  describe "when underlying user is nil" do
+    it "is not present, is blank and is nil" do
+      deferred_sign_in_user = Clearance::DeferredSignInUser.new(nil, "password")
+
+      expect(deferred_sign_in_user).not_to be_present
+      expect(deferred_sign_in_user).to be_blank
+      expect(deferred_sign_in_user).to be_nil
+    end
+  end
+
+  it "delegates other method calls to underlying user" do
+    user = double("user", first_name: "Foobar")
+    deferred_sign_in_user = Clearance::DeferredSignInUser.new(user, "password")
+
+    expect(deferred_sign_in_user.first_name).to eq("Foobar")
+  end
+
+  def stub_user(**options)
+    double("user").tap do |user|
+      allow(user).to receive(:authenticated?).
+        with(options[:password]).
+        once.
+        and_return(options[:authenticated])
+    end
+  end
+end

--- a/spec/deferred_sign_in_user_spec.rb
+++ b/spec/deferred_sign_in_user_spec.rb
@@ -1,6 +1,18 @@
 require "spec_helper"
+require "clearance/deferred_sign_in_user"
 
 describe Clearance::DeferredSignInUser do
+  describe "#deferred_sign_in_user" do
+    it "returns true" do
+      deferred_sign_in_user = Clearance::DeferredSignInUser.new(
+        nil,
+        "password"
+      )
+
+      expect(deferred_sign_in_user).to be_deferred_sign_in_user
+    end
+  end
+
   context "when an underlying user is present and authenticated" do
     it "is present, not blank and not nil" do
       user = stub_user(authenticated: true, password: "password")
@@ -46,7 +58,7 @@ describe Clearance::DeferredSignInUser do
     expect(deferred_sign_in_user.first_name).to eq("Foobar")
   end
 
-  def stub_user(**options)
+  def stub_user(options)
     double("user").tap do |user|
       allow(user).to receive(:authenticated?).
         with(options[:password]).

--- a/spec/user_spec.rb
+++ b/spec/user_spec.rb
@@ -39,7 +39,7 @@ describe User do
       password = user.password
 
       expect(User.authenticate(user.email, password)).to_not(
-        be_deferred_sign_in_user
+        be_deferred_sign_in_user,
       )
     end
 

--- a/spec/user_spec.rb
+++ b/spec/user_spec.rb
@@ -34,6 +34,15 @@ describe User do
       expect(User.authenticate(user.email, password)).to eq(user)
     end
 
+    it "is not a deferred signed in user" do
+      user = create(:user)
+      password = user.password
+
+      expect(User.authenticate(user.email, password)).to_not(
+        be_deferred_sign_in_user
+      )
+    end
+
     it "is authenticated with correct uppercased email and correct password" do
       user = create(:user)
       password = user.password
@@ -179,6 +188,12 @@ describe User do
       subject.send(:password=, password)
 
       expect(subject.encrypted_password).to_not be_nil
+    end
+  end
+
+  describe "#deferred_sign_in_user" do
+    it "returns false" do
+      expect(build(:user)).to_not be_deferred_sign_in_user
     end
   end
 end

--- a/spec/user_spec.rb
+++ b/spec/user_spec.rb
@@ -61,6 +61,31 @@ describe User do
 
       expect(User.find_by_normalized_email(user.email.upcase)).to eq(user)
     end
+
+    context "when defer_sign_in_password_check is enabled" do
+      before { Clearance.configuration.defer_sign_in_password_check = true }
+      after { restore_default_config }
+
+      it "returns a DeferredSignInUser when password is correct" do
+        user = create(:user)
+        deferred_signed_in_user = User.authenticate(user.email, "bad_password")
+
+        expect(deferred_signed_in_user).to eq user
+        expect(deferred_signed_in_user).to be_deferred_sign_in_user
+      end
+
+      it "returns a DeferredSignInUser when password is wrong" do
+        user = create(:user)
+        deferred_signed_in_user = User.authenticate(user.email, "bad_password")
+
+        expect(deferred_signed_in_user).to eq user
+        expect(deferred_signed_in_user).to be_deferred_sign_in_user
+      end
+
+      it "returns nil when user does not exist" do
+        expect(User.authenticate("foo@bar.com", "password")).to be_nil
+      end
+    end
   end
 
   describe ".reset_remember_token" do


### PR DESCRIPTION
## Introduction

This feature was born out of the need to implement an **Account Lock** mechanism, which works similarly to the one implemented in Devise (although much simpler).

Clearance's **Sign In** mechanism works with the following rules:
1. If a user exists in the database and the incoming password is **correct**,  a `user` object enters the `SignInGuard` stack.
2. If a user exists in the database and the incoming password is **incorrect**, a `nil` user object enters the `SignInGuard` stack.
3. If a user **does not exist in the database**, a `nil` user object enters the `SignInGuard` stack.
4. A user gets signed in _if_ the `current_user` object is not `nil` and the `SignInGuard` stack returns  `SuccessStatus`.

Unfortunately, the only way I was able to implement the **Account Lock** feature in my own app was by duplicating `SessionsController` and making an `AccountLockHandler` class, which acts as a pre-filter and runs the _account lock logic_ before handing out the user to `Clearance::Session#sign_in`, which in turns hands out the user to the `SignInGuard` stack.

The **Account Lock** feature requires working with an unauthenticated `user` object, so I could not use **Sign In Guards** because of the limitation described in item 2. I'm sure there are other features which would benefit from working with an unauthenticated user object.

My implementation felt particularly bad because:
- I had to duplicate Clearance's code in my app in order to get the feature working.
- Obeying the `current_user` rules described above, after my account lock pre-filter ran, felt a bit weird.
- This really feels like it should be handled by **Sign In Guards**.
## About the feature

I came up with this solution to make it possible to implement features such as **Account Lock** handlers _within_ **Sign In Guards**, while still keeping up with Clearance's philosophy of being small, simple and **extensible**, and not breaking up with existing Clearance contracts.

It works like this:
- The user enables a configuration option called `defer_sign_in_password_check`
- When signing in, the `Clearance::User.authenticate` method returns a `DeferredSignInUser` object. This is nothing but an augmented user wrapper (delegator), and does not check the user's password immediately, although it stores the password for a deferred check.
- The `SignInGuard` stack gets a `DeferredSignInUser` object – this allows guards to work with user objects regardless if they are authenticated or not.
- The `DeferredSignInUser#present?` method **only returns `true` if the user is present and authenticated**, so it works transparently with Clearance's current implementation.
- `ClearanceSession#signed_in?` delegates to `user#present?`, so `DefaultSignInGuard` will still do its job correctly without needing any changes.
## Alternative implementations

I built the feature in an opt-in manner, because I felt it would be a breaking change about how authentication and Sign In Guards work. In my opinion we should consider if this should indeed be the default behavior in future major versions, in order to extend the usefulness of Sign In Guards. That said, I'm OK with the way the feature got implemented in this PR.

There's an alternative, more explicit way to implement the feature, but it requires adding checks to `Clearance.configuration.defer_sign_in_password_check?` in lots of other spots, and ends up generating more code branches. I like the short and simple solution of having an augmented user, though a bit more implicit, but nevertheless well documented.
## Observations

If you have any questions, suggestions, comments, fixes, implementation ideas, anything, please don't hesitate to ask me. I've also left some descriptive text in the commits, to aid in answering possible questions.

Thank you
