### PR TITLE
Allow vendorizing of gems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 .bundle
 db/*.sqlite3
 gemfiles/*.lock
+gemfiles/vendor/
 log/*.log
 pkg
 tmp/

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'appraisal', '~> 1.0'
+gem 'appraisal'
 gem 'ammeter'
 gem 'bundler', '~> 1.3'
 gem 'capybara', '>= 2.6.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,7 +49,7 @@ GEM
       activesupport (>= 3.0)
       railties (>= 3.0)
       rspec-rails (>= 2.2)
-    appraisal (1.0.3)
+    appraisal (2.1.0)
       bundler
       rake
       thor (>= 0.14.0)
@@ -120,7 +120,7 @@ GEM
       activesupport (= 4.2.5)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
-    rake (10.4.2)
+    rake (11.1.2)
     rspec-core (3.4.1)
       rspec-support (~> 3.4.0)
     rspec-expectations (3.4.0)
@@ -162,7 +162,7 @@ PLATFORMS
 
 DEPENDENCIES
   ammeter
-  appraisal (~> 1.0)
+  appraisal
   bundler (~> 1.3)
   capybara (>= 2.6.2)
   clearance!
@@ -175,4 +175,4 @@ DEPENDENCIES
   timecop (~> 0.6)
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/gemfiles/rails40.gemfile
+++ b/gemfiles/rails40.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "appraisal", "~> 1.0"
+gem "appraisal"
 gem "ammeter"
 gem "bundler", "~> 1.3"
 gem "capybara", ">= 2.6.2"

--- a/gemfiles/rails41.gemfile
+++ b/gemfiles/rails41.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "appraisal", "~> 1.0"
+gem "appraisal"
 gem "ammeter"
 gem "bundler", "~> 1.3"
 gem "capybara", ">= 2.6.2"

--- a/gemfiles/rails42.gemfile
+++ b/gemfiles/rails42.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "appraisal", "~> 1.0"
+gem "appraisal"
 gem "ammeter"
 gem "bundler", "~> 1.3"
 gem "capybara", ">= 2.6.2"

--- a/gemfiles/rails50.gemfile
+++ b/gemfiles/rails50.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "appraisal", "~> 1.0"
+gem "appraisal"
 gem "ammeter"
 gem "bundler", "~> 1.3"
 gem "capybara", ">= 2.6.2"


### PR DESCRIPTION
I needed [this fix](https://github.com/thoughtbot/appraisal/commit/91eb5d63fdbc7237c6e1715b5569ac85a727a5d6) in order to get up and running, so I upgraded to the latest appraisal. Not sure if this was being held back for a specific reason?

/cc @derekprior 

Thanks!