### PR TITLE
User proper base class for User model

### DIFF
--- a/lib/generators/clearance/install/install_generator.rb
+++ b/lib/generators/clearance/install/install_generator.rb
@@ -24,10 +24,11 @@ module Clearance
           inject_into_file(
             "app/models/user.rb",
             "  include Clearance::User\n\n",
-            after: "class User < ActiveRecord::Base\n"
+            after: "class User < ",
           )
         else
-          copy_file 'user.rb', 'app/models/user.rb'
+          @inherit_from = models_inherit_from
+          template("user.rb.erb", "app/models/user.rb")
         end
       end
 
@@ -124,6 +125,14 @@ module Clearance
       def migration_version
         if Rails.version >= "5.0.0"
           "[#{Rails::VERSION::MAJOR}.#{Rails::VERSION::MINOR}]"
+        end
+      end
+
+      def models_inherit_from
+        if Rails.version >= "5.0.0"
+          "ApplicationRecord"
+        else
+          "ActiveRecord::Base"
         end
       end
     end

--- a/lib/generators/clearance/install/templates/user.rb
+++ b/lib/generators/clearance/install/templates/user.rb
@@ -1,3 +1,0 @@
-class User < ActiveRecord::Base
-  include Clearance::User
-end

--- a/lib/generators/clearance/install/templates/user.rb.erb
+++ b/lib/generators/clearance/install/templates/user.rb.erb
@@ -1,0 +1,3 @@
+class User < <%= @inherit_from %>
+  include Clearance::User
+end


### PR DESCRIPTION
In Rails 5, you are meant to have models that inherit from
`ApplicationRecord`. The code to inject clearance code into your
existing user model was hard-coded to look for a model that inherits
from `ActiveRecord::Base`. The specific inheritance requirement was
removed.

Similarly, applications that generated completely new user models were
set to inherit from `ActiveRecord::Base`. This should be
`ApplicationRecord` for Rails 5 and newer.