### PR TITLE
Custom cookie name configuration spec

### DIFF
--- a/spec/clearance/session_spec.rb
+++ b/spec/clearance/session_spec.rb
@@ -32,12 +32,12 @@ describe Clearance::Session do
 
   context "with a custom cookie name" do
     it "sets a custom cookie name in the header" do
-      Clearance.configuration.cookie_domain = "custom_token"
+      Clearance.configuration.cookie_name = "custom_cookie_name"
 
       session.sign_in user
       session.add_cookie_to_headers(headers)
 
-      expect(headers["Set-Cookie"]).to match(/custom_token/)
+      expect(headers["Set-Cookie"]).to match(/custom_cookie_name=.+;/)
     end
 
     after { restore_default_config }


### PR DESCRIPTION
In [session_spec.rb:33](https://github.com/thoughtbot/clearance/blob/master/spec/clearance/session_spec.rb#L33)'s custom cookie name spec, we are setting up `cookie_domain ` configuration and that makes the test suite green. We have the `cookie_domain` configuraiton spec on [session_spec.rb:278] (https://github.com/thoughtbot/clearance/blob/master/spec/clearance/session_spec.rb#L278), so I belive this is to test `cookie_name` configuration.

This commit changes the spec to test out the cookie name has been set properly in the header