### PR TITLE
Use flash alerts rather than notices

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,10 @@ complete changelog, see the git history for each version via the version links.
 - Removed support for Rails versions older than 4.2
 - Removed all deprecated code from Clearance 1.x
 
+### Changed
+- Flash messages now use `flash[:alert]` rather than `flash[:notice]` as they
+  were used as errors more than notices.
+
 [2.0.0]: https://github.com/thoughtbot/clearance/compare/v1.14.0...2.0
 
 ## [1.14.0] - April 29, 2016

--- a/app/controllers/clearance/passwords_controller.rb
+++ b/app/controllers/clearance/passwords_controller.rb
@@ -97,13 +97,13 @@ class Clearance::PasswordsController < Clearance::BaseController
   end
 
   def flash_failure_when_forbidden
-    flash.now[:notice] = translate(:forbidden,
+    flash.now[:alert] = translate(:forbidden,
       scope: [:clearance, :controllers, :passwords],
       default: t('flashes.failure_when_forbidden'))
   end
 
   def flash_failure_after_update
-    flash.now[:notice] = translate(:blank_password,
+    flash.now[:alert] = translate(:blank_password,
       scope: [:clearance, :controllers, :passwords],
       default: t('flashes.failure_after_update'))
   end

--- a/app/controllers/clearance/sessions_controller.rb
+++ b/app/controllers/clearance/sessions_controller.rb
@@ -24,7 +24,7 @@ class Clearance::SessionsController < Clearance::BaseController
       if status.success?
         redirect_back_or url_after_create
       else
-        flash.now.notice = status.failure_message
+        flash.now.alert = status.failure_message
         render template: "sessions/new", status: :unauthorized
       end
     end

--- a/lib/clearance/authorization.rb
+++ b/lib/clearance/authorization.rb
@@ -54,7 +54,7 @@ module Clearance
       store_location
 
       if flash_message
-        flash[:notice] = flash_message
+        flash[:alert] = flash_message
       end
 
       if signed_in?

--- a/lib/clearance/testing/deny_access_matcher.rb
+++ b/lib/clearance/testing/deny_access_matcher.rb
@@ -107,16 +107,14 @@ module Clearance
         def sets_the_flash?
           if @flash.blank?
             true
+          elsif flash_alert_value == @flash
+            @failure_message_when_negated <<
+              "Didn't expect to set the flash to #{@flash}"
+            true
           else
-            if flash_alert_value == @flash
-              @failure_message_when_negated <<
-                "Didn't expect to set the flash to #{@flash}"
-              true
-            else
-              @failure_message << "Expected the flash to be set to #{@flash} "\
-                "but was #{flash_alert_value}"
-              false
-            end
+            @failure_message << "Expected the flash to be set to #{@flash} "\
+              "but was #{flash_alert_value}"
+            false
           end
         end
       end

--- a/lib/clearance/testing/deny_access_matcher.rb
+++ b/lib/clearance/testing/deny_access_matcher.rb
@@ -8,7 +8,7 @@ module Clearance
     module Matchers
       # The `deny_access` matcher is used to assert that a
       #   request is denied access by clearance.
-      # @option opts [String] :flash The expected flash notice message. Defaults
+      # @option opts [String] :flash The expected flash alert message. Defaults
       #   to nil, which means the flash will not be checked.
       # @option opts [String] :redirect The expected redirect url. Defaults to
       #   `'/'` if signed in or the `sign_in_url` if signed out.
@@ -78,15 +78,15 @@ module Clearance
           @controller.request.env[:clearance]
         end
 
-        def flash_notice
-          @controller.flash[:notice]
+        def flash_alert
+          @controller.flash[:alert]
         end
 
-        def flash_notice_value
-          if flash_notice.respond_to?(:values)
-            flash_notice.values.first
+        def flash_alert_value
+          if flash_alert.respond_to?(:values)
+            flash_alert.values.first
           else
-            flash_notice
+            flash_alert
           end
         end
 
@@ -108,13 +108,13 @@ module Clearance
           if @flash.blank?
             true
           else
-            if flash_notice_value == @flash
+            if flash_alert_value == @flash
               @failure_message_when_negated <<
                 "Didn't expect to set the flash to #{@flash}"
               true
             else
               @failure_message << "Expected the flash to be set to #{@flash} "\
-                "but was #{flash_notice_value}"
+                "but was #{flash_alert_value}"
               false
             end
           end

--- a/spec/controllers/passwords_controller_spec.rb
+++ b/spec/controllers/passwords_controller_spec.rb
@@ -70,22 +70,22 @@ describe Clearance::PasswordsController do
     end
 
     context "blank token is supplied" do
-      it "renders the new password reset form with a flash notice" do
+      it "renders the new password reset form with a flash alert" do
         get :edit, user_id: 1, token: ""
 
         expect(response).to render_template(:new)
-        expect(flash.now[:notice]).to match(/double check the URL/i)
+        expect(flash.now[:alert]).to match(/double check the URL/i)
       end
     end
 
     context "invalid token is supplied" do
-      it "renders the new password reset form with a flash notice" do
+      it "renders the new password reset form with a flash alert" do
         user = create(:user, :with_forgotten_password)
 
         get :edit, user_id: 1, token: user.confirmation_token + "a"
 
         expect(response).to render_template(:new)
-        expect(flash.now[:notice]).to match(/double check the URL/i)
+        expect(flash.now[:alert]).to match(/double check the URL/i)
       end
     end
   end
@@ -128,7 +128,7 @@ describe Clearance::PasswordsController do
 
         put :update, update_parameters(user, new_password: "")
 
-        expect(flash.now[:notice]).to match(/password can't be blank/i)
+        expect(flash.now[:alert]).to match(/password can't be blank/i)
         expect(response).to render_template(:edit)
         expect(cookies[:remember_token]).to be_nil
       end

--- a/spec/controllers/permissions_controller_spec.rb
+++ b/spec/controllers/permissions_controller_spec.rb
@@ -62,7 +62,7 @@ describe PermissionsController do
     it "denies access to show and display a flash message" do
       get :show
 
-      expect(flash[:notice]).to match(/^Please sign in to continue/)
+      expect(flash[:alert]).to match(/^Please sign in to continue/)
     end
   end
 

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -31,7 +31,7 @@ describe Clearance::SessionsController do
         post :create, session: { email: user.email, password: user.password }
 
         expect(response).to render_template(:new)
-        expect(flash[:notice]).to match(/^Bad email or password/)
+        expect(flash[:alert]).to match(/^Bad email or password/)
       end
     end
 


### PR DESCRIPTION
These messages are used to tell users they can't access a page without
signing in, that their password is incorrect, etc. These are much closer
to error or alert states than notice.