### PR TITLE
Inject `include Clearance::User` inside model body

### DIFF
--- a/lib/generators/clearance/install/install_generator.rb
+++ b/lib/generators/clearance/install/install_generator.rb
@@ -24,7 +24,7 @@ module Clearance
           inject_into_file(
             "app/models/user.rb",
             "  include Clearance::User\n\n",
-            after: "class User < ",
+            after: "class User < #{models_inherit_from}\n",
           )
         else
           @inherit_from = models_inherit_from

--- a/spec/app_templates/app/models/rails5/user.rb
+++ b/spec/app_templates/app/models/rails5/user.rb
@@ -1,0 +1,5 @@
+class User < ApplicationRecord
+  def previously_existed?
+    true
+  end
+end

--- a/spec/generators/clearance/install/install_generator_spec.rb
+++ b/spec/generators/clearance/install/install_generator_spec.rb
@@ -37,8 +37,8 @@ describe Clearance::Generators::InstallGenerator, :generator do
 
         expect(user_class).to exist
         expect(user_class).to have_correct_syntax
+        expect(user_class).to contain_models_inherit_from
         expect(user_class).to contain("include Clearance::User")
-        expect(user_class).to contain proper_model_superclass
       end
     end
 
@@ -52,6 +52,7 @@ describe Clearance::Generators::InstallGenerator, :generator do
 
         expect(user_class).to exist
         expect(user_class).to have_correct_syntax
+        expect(user_class).to contain_models_inherit_from
         expect(user_class).to contain("include Clearance::User")
         expect(user_class).to have_method("previously_existed?")
       end
@@ -129,7 +130,11 @@ describe Clearance::Generators::InstallGenerator, :generator do
     end
   end
 
-  def proper_model_superclass
+  def contain_models_inherit_from
+    contain "< #{models_inherit_from}\n"
+  end
+
+  def models_inherit_from
     if Rails.version >= "5.0.0"
       "ApplicationRecord"
     else

--- a/spec/support/generator_spec_helpers.rb
+++ b/spec/support/generator_spec_helpers.rb
@@ -18,7 +18,7 @@ module GeneratorSpecHelpers
   end
 
   def provide_existing_user_class
-    copy_to_generator_root("app/models", "user.rb")
+    copy_to_generator_root("app/models", versionize_template("user.rb"))
     allow(File).to receive(:exist?).and_call_original
     allow(File).to receive(:exist?).with("app/models/user.rb").and_return(true)
   end
@@ -31,6 +31,14 @@ module GeneratorSpecHelpers
 
     FileUtils.mkdir_p(destination)
     FileUtils.cp(template_file, destination)
+  end
+
+  def versionize_template(template_file)
+    if Rails.version >= "5.0.0"
+      template_file = ["rails5", template_file].join("/")
+    end
+
+    template_file
   end
 end
 


### PR DESCRIPTION
Clearance generator was inserting `include Clearance::User` between `class User <` and `ActiveRecord::Base`, which is not correct.

Our spec was not checking if the generator was inserting clearance user model correctly or not. Let's add the test to ensure the generator is inserting the content properly. This commit fixes #676.