### PR TITLE
Use config.redirect_url in deny_access matcher

### DIFF
--- a/lib/clearance/testing/deny_access_matcher.rb
+++ b/lib/clearance/testing/deny_access_matcher.rb
@@ -68,7 +68,7 @@ module Clearance
 
         def denied_access_url
           if clearance_session.signed_in?
-            '/'
+            Clearance.configuration.redirect_url
           else
             @controller.sign_in_url
           end


### PR DESCRIPTION
The `deny_access` matched currently uses the hard coded path `/` for the
`singed_in?` case, but this does not match the implementation of the
`deny_access` helper, which uses `url_after_denied_access_when_signed_in` which
in turn uses the `Clearance.configuration.redirect_url`.

This change updates the `deny_access` matcher to also use the `redirect_url`.