### PR TITLE
remove unnecessary return from lib/clearance/user.rb

### DIFF
--- a/lib/clearance/user.rb
+++ b/lib/clearance/user.rb
@@ -135,7 +135,7 @@ module Clearance
       def authenticate(email, password)
         if user = find_by_normalized_email(email)
           if password.present? && user.authenticated?(password)
-            return user
+            user
           end
         end
       end


### PR DESCRIPTION
Hi! I was trying to use `clearance` and I found this small inaccuracy

**lib/clearance/user.rb**
```
def authenticate(email, password)
  if user = find_by_normalized_email(email)
    if password.present? && user.authenticated?(password)
      return user
    end
  end
end
```

I was decide corrected this, and make it in pr