### PR TITLE
Fix incompatibility with the attr encrypted gem

### DIFF
--- a/lib/clearance/password_strategies/bcrypt.rb
+++ b/lib/clearance/password_strategies/bcrypt.rb
@@ -19,18 +19,17 @@ module Clearance
         @password = new_password
 
         if new_password.present?
-          self.encrypted_password = encrypt(new_password)
+          self.encrypted_password = _encrypt(new_password)
         end
       end
 
       private
 
       # @api private
-      def encrypt(password)
+      def _encrypt(password)
         ::BCrypt::Password.create(password, cost: cost)
       end
 
-      # @api private
       def cost
         if test_environment?
           ::BCrypt::Engine::MIN_COST

--- a/lib/clearance/password_strategies/blowfish.rb
+++ b/lib/clearance/password_strategies/blowfish.rb
@@ -15,7 +15,7 @@ module Clearance
       #   gem
       def authenticated?(password)
         warn "#{Kernel.caller.first}: #{DEPRECATION_MESSAGE}"
-        encrypted_password == encrypt(password)
+        encrypted_password == _encrypt(password)
       end
 
       # @deprecated Use {BCrypt} or `clearance-deprecated_password_strategies`
@@ -26,14 +26,14 @@ module Clearance
         initialize_salt_if_necessary
 
         if new_password.present?
-          self.encrypted_password = encrypt(new_password)
+          self.encrypted_password = _encrypt(new_password)
         end
       end
 
       protected
 
       # @api private
-      def encrypt(string)
+      def _encrypt(string)
         generate_hash("--#{salt}--#{string}--")
       end
 

--- a/lib/clearance/password_strategies/sha1.rb
+++ b/lib/clearance/password_strategies/sha1.rb
@@ -16,7 +16,7 @@ module Clearance
       #   gem
       def authenticated?(password)
         warn "#{Kernel.caller.first}: #{DEPRECATION_MESSAGE}"
-        encrypted_password == encrypt(password)
+        encrypted_password == _encrypt(password)
       end
 
       # @deprecated Use {BCrypt} or `clearance-deprecated_password_strategies`
@@ -27,14 +27,14 @@ module Clearance
         initialize_salt_if_necessary
 
         if new_password.present?
-          self.encrypted_password = encrypt(new_password)
+          self.encrypted_password = _encrypt(new_password)
         end
       end
 
       private
 
       # @api private
-      def encrypt(string)
+      def _encrypt(string)
         generate_hash "--#{salt}--#{string}--"
       end
 

--- a/spec/password_strategies/bcrypt_spec.rb
+++ b/spec/password_strategies/bcrypt_spec.rb
@@ -69,6 +69,26 @@ describe Clearance::PasswordStrategies::BCrypt do
     end
   end
 
+  describe "#_encrypt" do
+    it "reserves #encrypt to prevent name conflicts with other gems" do
+      model_instance = fake_model_with_bcrypt_strategy
+
+      expect(model_instance.respond_to?(:encrypt, true)).to eq(false)
+    end
+
+    it "responds to #_encrypt" do
+      model_instance = fake_model_with_bcrypt_strategy
+
+      expect(model_instance.respond_to?(:_encrypt, true)).to eq(true)
+    end
+
+    it "ensures that #_encrypt is a private method as its name implies" do
+      model_instance = fake_model_with_bcrypt_strategy
+
+      expect(model_instance.respond_to?(:_encrypt)).to eq(false)
+    end
+  end
+
   def fake_model_with_bcrypt_strategy
     @model_instance ||= fake_model_with_password_strategy(
       Clearance::PasswordStrategies::BCrypt


### PR DESCRIPTION
Hi! I found this [issue](https://github.com/thoughtbot/clearance/issues/685), and I try to fix it in this way:
private method `encrypt` have a one line and is used once in the setter-method `password=()`. I suggest to remove method `encrypt` and used `::BCrypt::Password.create(password, cost: cost)` straight in to `password=()`.