### PR TITLE
Inline bcrypt password strategy helpers

### DIFF
--- a/lib/clearance/password_strategies/bcrypt.rb
+++ b/lib/clearance/password_strategies/bcrypt.rb
@@ -19,29 +19,17 @@ module Clearance
         @password = new_password
 
         if new_password.present?
-          self.encrypted_password = encrypt(new_password)
+          cost = if defined?(::Rails) && ::Rails.env.test?
+                   ::BCrypt::Engine::MIN_COST
+                 else
+                   ::BCrypt::Engine::DEFAULT_COST
+                 end
+
+          self.encrypted_password = ::BCrypt::Password.create(
+            new_password,
+            cost: cost,
+          )
         end
-      end
-
-      private
-
-      # @api private
-      def encrypt(password)
-        ::BCrypt::Password.create(password, cost: cost)
-      end
-
-      # @api private
-      def cost
-        if test_environment?
-          ::BCrypt::Engine::MIN_COST
-        else
-          ::BCrypt::Engine::DEFAULT_COST
-        end
-      end
-
-      # @api private
-      def test_environment?
-        defined?(::Rails) && ::Rails.env.test?
       end
     end
   end


### PR DESCRIPTION
The bcrypt password strategy had some private helper functions that
cleaned up the `password=` method. These private helper functions end up
getting mixed into the end application's `User` class because password
strategies are implemented as mixins. This causes issues if the user
class has `encrypt` or `cost` methods already. `attr_encrypted`, for
instance, mixes in its own `encrypt` method.

I considered renaming the helper functions, prefacing them with
`clearance_` or something similar. I also considered nesting the helpers
in a module and calling them as such. In the end, I felt inlining the
helpers made the code marginally less readable but fixed the conflict
problem without the added ceremony of a module.