### PR TITLE
Do not generate application layout file

### DIFF
--- a/spec/acceptance/clearance_installation_spec.rb
+++ b/spec/acceptance/clearance_installation_spec.rb
@@ -38,7 +38,6 @@ describe "Clearance Installation" do
     CMD
 
     FileUtils.rm_f("public/index.html")
-    FileUtils.rm_f("app/views/layouts/application.html.erb")
   end
 
   def testapp_templates
@@ -47,7 +46,6 @@ describe "Clearance Installation" do
 
   def configure_test_app
     FileUtils.rm_f("public/index.html")
-    FileUtils.rm_f("app/views/layouts/application.html.erb")
     FileUtils.cp_r(testapp_templates, "..")
   end
 

--- a/spec/app_templates/testapp/app/views/layouts/application.html.erb
+++ b/spec/app_templates/testapp/app/views/layouts/application.html.erb
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <%= javascript_include_tag 'application' %>
+    <%= csrf_meta_tag %>
+  </head>
+  <body>
+    <div id="header">
+      <% if signed_in? -%>
+        <%= button_to t(".sign_out"), sign_out_path, method: :delete %>
+      <% else -%>
+        <%= link_to t(".sign_in"), sign_in_path %>
+      <% end -%>
+    </div>
+
+    <div id="flash">
+      <% flash.each do |key, value| -%>
+        <div id="flash_<%= key %>"><%=h value %></div>
+      <% end %>
+    </div>
+
+    <%= yield %>
+  </body>
+</html>

--- a/spec/generators/clearance/views/views_generator_spec.rb
+++ b/spec/generators/clearance/views/views_generator_spec.rb
@@ -8,7 +8,6 @@ describe Clearance::Generators::ViewsGenerator, :generator do
     views = %w(
       clearance_mailer/change_password.html.erb
       clearance_mailer/change_password.text.erb
-      layouts/application.html.erb
       passwords/create.html.erb
       passwords/edit.html.erb
       passwords/new.html.erb


### PR DESCRIPTION
As mentioned in https://github.com/thoughtbot/clearance/issues/701, (which this solves), adding the application layout file to the list of views managed by Clearance can lead to unexpected/adverse effects.

While it is true that including the file with the suggested implementation of flashes and sign in/sign out logic is valuable in providing both a clear example of what is necessary to implement the library and in a good out-of-the-box experience, it can lead to inadvertently overriding the existing layout or, like in the issue mentioned above, have a surprising destructive effect when relying on
Rails generators to undo the views being copied.

Also, the very same implementation suggestion is presented to Stdout when running the installer, so this change does not imply the loss of any helpful input.

The PR moves the layout file to the testing application `spec/app_templates/testapp/app/views/layouts/application.html.erb` in order to maintain the acceptance tests passing as expected, and removes `application.html.erb` from the list of files managed under the Clearance generator.
