### PR TITLE
Prevent password reset token leak via HTTP referer

### DIFF
--- a/app/controllers/clearance/passwords_controller.rb
+++ b/app/controllers/clearance/passwords_controller.rb
@@ -29,6 +29,7 @@ class Clearance::PasswordsController < Clearance::BaseController
 
   def edit
     @user = find_user_for_edit
+    @user.forgot_password!
     render template: 'passwords/edit'
   end
 

--- a/spec/controllers/passwords_controller_spec.rb
+++ b/spec/controllers/passwords_controller_spec.rb
@@ -67,6 +67,15 @@ describe Clearance::PasswordsController do
         expect(response).to render_template(:edit)
         expect(assigns(:user)).to eq user
       end
+
+      it "immediately expires the supplied token" do
+        user = create(:user, :with_forgotten_password)
+        token = user.confirmation_token
+
+        get :edit, user_id: user, token: token
+
+        expect(user.reload.confirmation_token).not_to eq(token)
+      end
     end
 
     context "blank token is supplied" do


### PR DESCRIPTION
The password reset token is included in the URL emailed to users who
request a password reset. When the user clicks the link, they are
brought to the password reset form. If instead of completing the form
the user clicks a link to another HTTPS resource that may be in the site
navigation, then the password reset token will be leaked to that
external site via HTTP referer (sic).

Taking advantage of this would require an attack to:

1. Control a site that is linked to on the password reset token
2. Capture any HTTP referers that contain the token
3. Use the referer URL to complete the password reset before the user
does so themselves.

This is a rather involved exploit, but something we should close
nonetheless. We address it in this change by rotating the password reset
token on the edit page. This will cause the displayed form to submit
with the new, updated password reset token. The token in the form will
be valid, while the token in the URL is now invalid. If the URL token is
leaked, it will be useless to an attacker.

This is the simplest change I could think of to fix this in a likely
backward compatible way. If developers have overridden
`Clearance::Passwords#edit` without calling `super`, they will have to
implement the same fix locally.

This change could impact end users who click the reset link and for
whatever reason do not complete the reset. If they were to use that same
link again, it would now be invalid. This is consistent with other
password reset systems that expire tokens immediately or with a short
timeout.