### PR TITLE
Prevent password reset token leak via HTTP referer

### DIFF
--- a/app/controllers/clearance/passwords_controller.rb
+++ b/app/controllers/clearance/passwords_controller.rb
@@ -29,7 +29,13 @@ class Clearance::PasswordsController < Clearance::BaseController
 
   def edit
     @user = find_user_for_edit
-    render template: 'passwords/edit'
+
+    if params[:token]
+      session[:password_reset_token] = params[:token]
+      redirect_to edit_user_password_url(@user)
+    else
+      render template: 'passwords/edit'
+    end
   end
 
   def new
@@ -42,6 +48,7 @@ class Clearance::PasswordsController < Clearance::BaseController
     if @user.update_password password_reset_params
       sign_in @user
       redirect_to url_after_update
+      session[:password_reset_token] = nil
     else
       flash_failure_after_update
       render template: 'passwords/edit'
@@ -71,9 +78,10 @@ class Clearance::PasswordsController < Clearance::BaseController
 
   def find_user_by_id_and_confirmation_token
     user_param = Clearance.configuration.user_id_parameter
+    token = session[:password_reset_token] || params[:token]
 
     Clearance.configuration.user_model.
-      find_by_id_and_confirmation_token params[user_param], params[:token].to_s
+      find_by_id_and_confirmation_token params[user_param], token.to_s
   end
 
   def find_user_for_create

--- a/spec/controllers/passwords_controller_spec.rb
+++ b/spec/controllers/passwords_controller_spec.rb
@@ -57,11 +57,24 @@ describe Clearance::PasswordsController do
   end
 
   describe "#edit" do
-    context "valid id and token are supplied" do
-      it "renders the password form for the user" do
+    context "valid id and token are supplied in url" do
+      it "redirects to the edit page with token now removed from url" do
         user = create(:user, :with_forgotten_password)
 
         get :edit, user_id: user, token: user.confirmation_token
+
+        expect(response).to be_redirect
+        expect(response).to redirect_to edit_user_password_url(user)
+        expect(session[:password_reset_token]).to eq user.confirmation_token
+      end
+    end
+
+    context "valid id in url and valid token in session" do
+      it "renders the password reset form" do
+        user = create(:user, :with_forgotten_password)
+
+        request.session[:password_reset_token] = user.confirmation_token
+        get :edit, user_id: user
 
         expect(response).to be_success
         expect(response).to render_template(:edit)


### PR DESCRIPTION
The password reset token is included in the URL emailed to users who
request a password reset. When the user clicks the link, they are
brought to the password reset form. If instead of completing the form
the user clicks a link to another HTTPS resource that may be in the site
navigation, then the password reset token will be leaked to that
external site via HTTP referer (sic).

Taking advantage of this would require an attack to:

1. Control a site that is linked to on the password reset token
2. Capture any HTTP referers that contain the token
3. Use the referer URL to complete the password reset before the user
does so themselves.

This is a rather involved exploit, but something we should close
nonetheless. We address it in this change by requiring that the token be
present in the session rather than in the URL before the page is
displayed to the user. If the user hits the edit action with a token in
the URL, the token will be stored in the session and the user will be
redirected to the same URL minus the token.

This is a bit more complicated the another change I considered where we
simply rotate the token before the form is displayed. While this change
is more involved and less localized, it has the advantage of maintaining
the side-effect-free `get` (kind of - we do mutate the session).