### PR TITLE
make redirect to password redirect page dynamic, simply redirect to the current page

### DIFF
--- a/app/controllers/clearance/passwords_controller.rb
+++ b/app/controllers/clearance/passwords_controller.rb
@@ -32,7 +32,7 @@ class Clearance::PasswordsController < Clearance::BaseController
 
     if params[:token]
       session[:password_reset_token] = params[:token]
-      redirect_to edit_user_password_url(@user)
+      redirect_to url_for
     else
       render template: 'passwords/edit'
     end


### PR DESCRIPTION
After upgrading to v0.15 I ran into the problem that the URL helper for the "edit password" page in my app is not called `edit_user_password_url` but `edit_password_url`.
Since [the redirect](https://github.com/thoughtbot/clearance/blob/v1.15.0/app/controllers/clearance/passwords_controller.rb#L35) should always go the same page that is being requested right now, just without the param, I suggest to use `url_for` instead.

The tests pass. Not sure if another test is necessary?