### PR TITLE
Remove users/password#create route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ if Clearance.configuration.routes_enabled?
       only: Clearance.configuration.user_actions do
         resource :password,
           controller: 'clearance/passwords',
-          only: [:create, :edit, :update]
+          only: [:edit, :update]
       end
 
     get '/sign_in' => 'clearance/sessions#new', as: 'sign_in'

--- a/lib/generators/clearance/routes/templates/routes.rb
+++ b/lib/generators/clearance/routes/templates/routes.rb
@@ -4,7 +4,7 @@
   resources :users, controller: "clearance/users", only: [:create] do
     resource :password,
       controller: "clearance/passwords",
-      only: [:create, :edit, :update]
+      only: [:edit, :update]
   end
 
   get "/sign_in" => "clearance/sessions#new", as: "sign_in"


### PR DESCRIPTION
* There is a route for password#create nested in the users resource,
  and I can't figure out why you would need to create a password reset if
  you are logged in as a user. This seems like a useless route unless
  I am missing something.
* Remove the route for password#create under users
* Remove the route from the generator template