### PR TITLE
Reset Rails session on sign out

### DIFF
--- a/lib/clearance/authentication.rb
+++ b/lib/clearance/authentication.rb
@@ -66,10 +66,14 @@ module Clearance
       clearance_session.sign_in user, &block
     end
 
-    # Destroy the current user's Clearance session.
-    # See {Session#sign_out} for specifics.
+    # Destroy the current user's Clearance and Rails sessions.
+    # See {Session#sign_out} for Clearance specifics. The Rails
+    # session itself is also reset as it is common practice for
+    # application developers to store user-specific information
+    # there.
     def sign_out
       clearance_session.sign_out
+      reset_session
     end
 
     # True if there is a currently-signed-in user. Exposed as a `helper_method`,

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -82,6 +82,7 @@ describe Clearance::SessionsController do
         @user = create(:user)
         @user.update_attribute :remember_token, "old-token"
         @request.cookies["remember_token"] = "old-token"
+        session["test"] = "present"
         delete :destroy
       end
 
@@ -93,6 +94,10 @@ describe Clearance::SessionsController do
 
       it "should unset the current user" do
         expect(request.env[:clearance].current_user).to be_nil
+      end
+
+      it "should reset the rails session" do
+        expect(session["test"]).to be_nil
       end
     end
   end


### PR DESCRIPTION
Signing out currently removes only the dedicated Clearance remember
token cookie. The Rails session itself is left intact because, as far
as Clearance is concerned, there is no user-specific information stored
there. This is true, but is also naive. It's common for Rails developers
to store user-specific information in `session`.

Resetting the session will also cause the CSRF token to be rotated. CSRF
issues typically involve signed-in users and Clearance sign out does not
leave the user signed in, so there's not much value to a CSRF attack
against a session in this state. Still, rotating the token is a best
practice.