### PR TITLE
Reset CSRF token on sign in

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,16 @@ Clearance.configure do |config|
   config.mailer_sender = "reply@example.com"
   config.password_strategy = Clearance::PasswordStrategies::BCrypt
   config.redirect_url = "/"
+  config.rotate_csrf_on_sign_in = false
   config.secure_cookie = false
   config.sign_in_guards = []
   config.user_model = User
 end
 ```
+
+The install generator will set `rotate_csrf_on_sign_in` to `true`, so new
+installations will get this behavior from the start. This helps avoid session
+fixation attacks, and will become the default in Clearance 2.0.
 
 ## Use
 

--- a/lib/clearance/authentication.rb
+++ b/lib/clearance/authentication.rb
@@ -62,8 +62,16 @@ module Clearance
     #
     # For an example of how clearance uses this internally, see
     # {SessionsController#create}.
+    #
+    # Signing in will also regenerate the CSRF token for the current session,
+    # provided {Configuration#rotate_csrf_token_on_sign_in} is set.
     def sign_in(user, &block)
-      clearance_session.sign_in user, &block
+      clearance_session.sign_in(user, &block)
+
+      if signed_in? && Clearance.configuration.rotate_csrf_on_sign_in?
+        session.delete(:_csrf_token)
+        form_authenticity_token
+      end
     end
 
     # Destroy the current user's Clearance session.

--- a/lib/clearance/configuration.rb
+++ b/lib/clearance/configuration.rb
@@ -58,6 +58,11 @@ module Clearance
     # @return [String]
     attr_accessor :redirect_url
 
+    # Controls whether Clearance will rotate the CSRF token on sign in.
+    # Defaults to `nil` which generates a warning. Will default to true in
+    # Clearance 2.0.
+    attr_accessor :rotate_csrf_on_sign_in
+
     # Set to `false` to disable Clearance's built-in routes.
     # Defaults to `true`. When set to false, your app is responsible for all
     # routes. You can dump a copy of Clearance's default routes with
@@ -95,6 +100,7 @@ module Clearance
       @mailer_sender = 'reply@example.com'
       @redirect_url = '/'
       @routes = true
+      @rotate_csrf_on_sign_in = nil
       @secure_cookie = false
       @sign_in_guards = []
     end
@@ -152,6 +158,25 @@ module Clearance
       if @user_model.present?
         @user_model = @user_model.to_s.constantize
       end
+    end
+
+    def rotate_csrf_on_sign_in?
+      if rotate_csrf_on_sign_in.nil?
+        warn <<-EOM.squish
+          Clearance's `rotate_csrf_on_sign_in` configration setting is unset and
+          will be treated as `false`. Setting this value to `true` is
+          recommended to avoid session fixation attacks and will be the default
+          in Clearance 2.0. It is recommended that you opt-in to this setting
+          now and test your application. To silence this warning, set
+          `rotate_csrf_on_sign_in` to `true` or `false` in Clearance's
+          inializer.
+
+          For more information on session fixation, see:
+            https://www.owasp.org/index.php/Session_fixation
+        EOM
+      end
+
+      rotate_csrf_on_sign_in
     end
   end
 

--- a/lib/generators/clearance/install/templates/clearance.rb
+++ b/lib/generators/clearance/install/templates/clearance.rb
@@ -1,3 +1,4 @@
 Clearance.configure do |config|
   config.mailer_sender = "reply@example.com"
+  config.rotate_csrf_on_sign_in = true
 end

--- a/spec/clearance/session_spec.rb
+++ b/spec/clearance/session_spec.rb
@@ -39,8 +39,6 @@ describe Clearance::Session do
 
       expect(headers["Set-Cookie"]).to match(/custom_cookie_name=.+;/)
     end
-
-    after { restore_default_config }
   end
 
   describe '#sign_in' do
@@ -113,7 +111,6 @@ describe Clearance::Session do
         expect(session.current_user).to be_nil
       end
 
-
       def stub_sign_in_guard(options)
         session_status = stub_status(options.fetch(:succeed))
 
@@ -159,8 +156,6 @@ describe Clearance::Session do
 
       expect(headers['Set-Cookie']).to match(/remember_token=.+; HttpOnly/)
     end
-
-    after { restore_default_config }
   end
 
   context 'if httponly is not set' do
@@ -270,8 +265,6 @@ describe Clearance::Session do
 
         expect(headers['Set-Cookie']).to match(/remember_token=.+; secure/)
       end
-
-      after { restore_default_config }
     end
   end
 
@@ -287,8 +280,6 @@ describe Clearance::Session do
 
         expect(headers['Set-Cookie']).to match(/domain=\.example\.com; path/)
       end
-
-      after { restore_default_config }
     end
 
     context 'when not set' do
@@ -324,8 +315,6 @@ describe Clearance::Session do
 
         expect(headers['Set-Cookie']).to match(/path=\/user; expires/)
       end
-
-      after { restore_default_config }
     end
   end
 
@@ -375,7 +364,5 @@ describe Clearance::Session do
   def with_custom_expiration(custom_duration)
     Clearance.configuration.cookie_expiration = custom_duration
     yield
-  ensure
-    restore_default_config
   end
 end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -1,8 +1,6 @@
 require "spec_helper"
 
 describe Clearance::Configuration do
-  after { restore_default_config }
-
   context "when no user_model_name is specified" do
     it "defaults to User" do
       expect(Clearance.configuration.user_model).to eq ::User
@@ -144,6 +142,32 @@ describe Clearance::Configuration do
       Clearance.configuration = Clearance::Configuration.new
 
       expect(Clearance.configuration.reload_user_model).to be_nil
+    end
+  end
+
+  describe "#rotate_csrf_on_sign_in?" do
+    it "defaults to falsey and warns" do
+      Clearance.configuration = Clearance::Configuration.new
+      allow(Clearance.configuration).to receive(:warn)
+
+      expect(Clearance.configuration.rotate_csrf_on_sign_in?).to be_falsey
+      expect(Clearance.configuration).to have_received(:warn)
+    end
+
+    it "is true and does not warn when `rotate_csrf_on_sign_in` is true" do
+      Clearance.configure { |config| config.rotate_csrf_on_sign_in = true }
+      allow(Clearance.configuration).to receive(:warn)
+
+      expect(Clearance.configuration.rotate_csrf_on_sign_in?).to be true
+      expect(Clearance.configuration).not_to have_received(:warn)
+    end
+
+    it "is false and does not warn when `rotate_csrf_on_sign_in` is false" do
+      Clearance.configure { |config| config.rotate_csrf_on_sign_in = false }
+      allow(Clearance.configuration).to receive(:warn)
+
+      expect(Clearance.configuration.rotate_csrf_on_sign_in?).to be false
+      expect(Clearance.configuration).not_to have_received(:warn)
     end
   end
 end

--- a/spec/requests/csrf_rotation_spec.rb
+++ b/spec/requests/csrf_rotation_spec.rb
@@ -1,0 +1,33 @@
+require "spec_helper"
+
+describe "CSRF Rotation" do
+  around do |example|
+    ActionController::Base.allow_forgery_protection = true
+    example.run
+    ActionController::Base.allow_forgery_protection = false
+  end
+
+  context "Clearance is configured to rotate CSRF token on sign in" do
+    describe "sign in" do
+      it "rotates the CSRF token" do
+        Clearance.configure { |config| config.rotate_csrf_on_sign_in = true }
+        get sign_in_path
+        user = create(:user, password: "password")
+        original_token = csrf_token
+
+        post session_path, session: session_params(user, "password")
+
+        expect(csrf_token).not_to eq original_token
+        expect(csrf_token).to be_present
+      end
+    end
+  end
+
+  def csrf_token
+    session[:_csrf_token]
+  end
+
+  def session_params(user, password)
+    { email: user.email, password: password, authenticity_token: csrf_token }
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,6 +27,8 @@ RSpec.configure do |config|
     mocks.syntax = :expect
   end
 
+  config.before { restore_default_warning_free_config }
+
   if Rails::VERSION::MAJOR >= 5
     require 'rails-controller-testing'
     config.include Rails::Controller::Testing::TestProcess
@@ -35,7 +37,7 @@ RSpec.configure do |config|
   end
 end
 
-def restore_default_config
+def restore_default_warning_free_config
   Clearance.configuration = nil
-  Clearance.configure {}
+  Clearance.configure { |config| config.rotate_csrf_on_sign_in = true }
 end


### PR DESCRIPTION
By rotating this token, we can prevent session fixation attacks. This is
the simplest explanation of session fixation that I've found, and I do
not want to recreate it here: https://www.owasp.org/index.php/Session_fixation

By rotating the CSRF token on sign in, the attacker will be unable to
make authenticated requests using the known session ID as they will not
have access to the new CSRF token without an additional security
vulnerability.

While I believe this should cause most Clearance users no harm if
enabled by default, there's a chance that it may, particularly if sign
in is done via AJAX, as additional form submissions after sign in will
not have the updated CSRF token.

For that reason, this feature is behind a configuration setting. The
configuration is `nil` by default, which will generate a warning that
encourages the user to set it to `true`, but the warning can be silenced
by setting the configuration to any value.