### PR TITLE
Remove unused nested `create` routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ if Clearance.configuration.routes_enabled?
       only: Clearance.configuration.user_actions do
         resource :password,
           controller: 'clearance/passwords',
-          only: [:create, :edit, :update]
+          only: [:edit, :update]
       end
 
     get '/sign_in' => 'clearance/sessions#new', as: 'sign_in'


### PR DESCRIPTION
In the routes file, we have two `create` routes defined for the `password` resource. One on the `password` resources and another one as nested `member` routes for users, but we only use the `resources` one to reset user's password.

This commit removes the unused nested `create` routes for the password resource.

Ref:

- https://github.com/thoughtbot/clearance/blob/master/config/routes.rb#L3-L5
- https://github.com/thoughtbot/clearance/blob/master/config/routes.rb#L16