### PR TITLE
Cleanup `Clearance::PasswordsController#new` spec

### DIFF
--- a/spec/controllers/passwords_controller_spec.rb
+++ b/spec/controllers/passwords_controller_spec.rb
@@ -5,9 +5,7 @@ describe Clearance::PasswordsController do
 
   describe "#new" do
     it "renders the password reset form" do
-      user = create(:user)
-
-      get :new, user_id: user
+      get :new
 
       expect(response).to be_success
       expect(response).to render_template(:new)


### PR DESCRIPTION
In the `Clearance::PasswordsController#new` spec we are passing the `user_id` for the `new` action, which is not necessary to render the password reset form. So let's clean that up :)