### PR TITLE
Avoid NoMethodError when receiving invalid params

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,15 @@
 The noteworthy changes for each Clearance version are included here. For a
 complete changelog, see the git history for each version via the version links.
 
+## Unreleased
+
+### Fixed
+
+- Fix issue where invalid params could raise `NoMethodError` when updating and
+  resetting passwords.
+
+[Unreleased]: https://github.com/thoughtbot/clearance/compare/v2.0.0.beta2...HEAD
+
 ## [2.0.0.beta2] - September 17, 2019
 
 ### Added

--- a/app/controllers/clearance/passwords_controller.rb
+++ b/app/controllers/clearance/passwords_controller.rb
@@ -31,7 +31,7 @@ class Clearance::PasswordsController < Clearance::BaseController
   def update
     @user = find_user_for_update
 
-    if @user.update_password password_reset_params
+    if @user.update_password(password_from_password_reset_params)
       sign_in @user
       redirect_to url_after_update
       session[:password_reset_token] = nil
@@ -48,8 +48,8 @@ class Clearance::PasswordsController < Clearance::BaseController
     mail.deliver_later
   end
 
-  def password_reset_params
-    params[:password_reset][:password]
+  def password_from_password_reset_params
+    params.dig(:password_reset, :password)
   end
 
   def find_user_by_id_and_confirmation_token
@@ -60,9 +60,13 @@ class Clearance::PasswordsController < Clearance::BaseController
       find_by_id_and_confirmation_token params[user_param], token.to_s
   end
 
+  def email_from_password_params
+    params.dig(:password, :email)
+  end
+
   def find_user_for_create
     Clearance.configuration.user_model.
-      find_by_normalized_email params[:password][:email]
+      find_by_normalized_email(email_from_password_params)
   end
 
   def find_user_for_edit

--- a/spec/controllers/passwords_controller_spec.rb
+++ b/spec/controllers/passwords_controller_spec.rb
@@ -37,6 +37,16 @@ describe Clearance::PasswordsController do
       end
     end
 
+    context "email param is missing" do
+      it "does not raise error" do
+        expect do
+          post :create, params: {
+            password: {},
+          }
+        end.not_to raise_error
+      end
+    end
+
     context "email does not belong to an existing user" do
       it "does not deliver an email" do
         ActionMailer::Base.deliveries.clear
@@ -164,6 +174,18 @@ describe Clearance::PasswordsController do
         user.reload
         expect(user.encrypted_password).to eq old_encrypted_password
         expect(user.confirmation_token).to be_present
+      end
+
+      it "does not raise NoMethodError from incomplete password_reset params" do
+        user = create(:user, :with_forgotten_password)
+
+        expect do
+          put :update, params: {
+            user_id: user,
+            token: user.confirmation_token,
+            password_reset: {},
+          }
+        end.not_to raise_error
       end
 
       it "re-renders the password edit form" do


### PR DESCRIPTION
Previously, the `PasswordsController` assumed that well-formed input was
being passed to it via the password reset forms. While this is usually
the case, we can't control bad actors from probing however they'd like
and generating exceptions when this happens distracts from valuable
exception reports.

Fixes #715