### PR TITLE
Unique constraints for tokens

### DIFF
--- a/app/controllers/clearance/passwords_controller.rb
+++ b/app/controllers/clearance/passwords_controller.rb
@@ -76,12 +76,9 @@ class Clearance::PasswordsController < Clearance::BaseController
     end
   end
 
-  def find_user_by_id_and_confirmation_token
-    user_param = Clearance.configuration.user_id_parameter
+  def find_user_by_confirmation_token
     token = session[:password_reset_token] || params[:token]
-
-    Clearance.configuration.user_model.
-      find_by_id_and_confirmation_token params[user_param], token.to_s
+    Clearance.configuration.user_model.find_by_confirmation_token token.to_s
   end
 
   def find_user_for_create
@@ -90,15 +87,15 @@ class Clearance::PasswordsController < Clearance::BaseController
   end
 
   def find_user_for_edit
-    find_user_by_id_and_confirmation_token
+    find_user_by_confirmation_token
   end
 
   def find_user_for_update
-    find_user_by_id_and_confirmation_token
+    find_user_by_confirmation_token
   end
 
   def ensure_existing_user
-    unless find_user_by_id_and_confirmation_token
+    unless find_user_by_confirmation_token
       flash_failure_when_forbidden
       render template: "passwords/new"
     end

--- a/app/views/clearance_mailer/change_password.html.erb
+++ b/app/views/clearance_mailer/change_password.html.erb
@@ -2,7 +2,7 @@
 
 <p>
   <%= link_to t(".link_text", default: "Change my password"),
-    edit_user_password_url(@user, token: @user.confirmation_token.html_safe) %>
+    edit_user_password_url(token: @user.confirmation_token.html_safe) %>
 </p>
 
 <p><%= raw t(".closing") %></p>

--- a/app/views/clearance_mailer/change_password.text.erb
+++ b/app/views/clearance_mailer/change_password.text.erb
@@ -1,5 +1,5 @@
 <%= t(".opening") %>
 
-<%= edit_user_password_url(@user, token: @user.confirmation_token.html_safe) %>
+<%= edit_user_password_url(token: @user.confirmation_token.html_safe) %>
 
 <%= raw t(".closing") %>

--- a/app/views/passwords/edit.html.erb
+++ b/app/views/passwords/edit.html.erb
@@ -4,7 +4,7 @@
   <p><%= t(".description") %></p>
 
   <%= form_for :password_reset,
-        url: user_password_path(@user, token: @user.confirmation_token),
+        url: user_password_path(token: @user.confirmation_token),
         html: { method: :put } do |form| %>
     <div class="password-field">
       <%= form.label :password %>

--- a/lib/generators/clearance/install/templates/db/migrate/create_users.rb
+++ b/lib/generators/clearance/install/templates/db/migrate/create_users.rb
@@ -9,6 +9,7 @@ class CreateUsers < ActiveRecord::Migration<%= migration_version %>
     end
 
     add_index :users, :email
-    add_index :users, :remember_token
+    add_index :users, :remember_token, unique: true
+    add_index :users, :confirmation_token, unique: true
   end
 end

--- a/spec/controllers/passwords_controller_spec.rb
+++ b/spec/controllers/passwords_controller_spec.rb
@@ -62,7 +62,7 @@ describe Clearance::PasswordsController do
         get :edit, user_id: user, token: user.confirmation_token
 
         expect(response).to be_redirect
-        expect(response).to redirect_to edit_user_password_url(user)
+        expect(response).to redirect_to edit_user_password_url
         expect(session[:password_reset_token]).to eq user.confirmation_token
       end
     end


### PR DESCRIPTION
inspired by discussion here: #726

The first commit to the migration simply adds unique constraints to the columns, which @derekprior  said he would invite (not sure if that meant for one or both token types)

The second commit takes advantage of the constraints, because user_id is now redundant.

I wasn't able to get my environment to run tests (ruby 2.4 problem?) so I just put this together for discussion, to see what changes are welcome.

If removing the user_id requirement isn't desirable, then the index in the first commit could be updated to be multi-column, `[:user_id, :confirmation_token]`.

LMKWYT!
