### PR TITLE
Fixes install generator to create users table on connect exception

### DIFF
--- a/lib/generators/clearance/install/install_generator.rb
+++ b/lib/generators/clearance/install/install_generator.rb
@@ -102,10 +102,16 @@ module Clearance
       end
 
       def users_table_exists?
-        if ActiveRecord::Base.connection.respond_to?(:data_source_exists?)
-          ActiveRecord::Base.connection.data_source_exists?(:users)
+        begin
+          connection = ActiveRecord::Base.connection
+        rescue ActiveRecord::NoDatabaseError
+          return false
+        end
+
+        if connection.respond_to?(:data_source_exists?)
+          connection.data_source_exists?(:users)
         else
-          ActiveRecord::Base.connection.table_exists?(:users)
+          connection.table_exists?(:users)
         end
       end
 

--- a/spec/generators/clearance/install/install_generator_spec.rb
+++ b/spec/generators/clearance/install/install_generator_spec.rb
@@ -74,6 +74,20 @@ describe Clearance::Generators::InstallGenerator, :generator do
       end
     end
 
+    context "database does not exist" do
+      it "creates a migration to create the users table" do
+        provide_existing_application_controller
+        database_does_not_exist
+
+        run_generator
+        migration = migration_file("db/migrate/create_users.rb")
+
+        expect(migration).to exist
+        expect(migration).to have_correct_syntax
+        expect(migration).to contain("create_table :users")
+      end
+    end
+
     context "existing users table with all clearance columns and indexes" do
       it "does not create a migration" do
         provide_existing_application_controller
@@ -128,6 +142,11 @@ describe Clearance::Generators::InstallGenerator, :generator do
         with(name).
         and_return(false)
     end
+  end
+
+  def database_does_not_exist
+    fake_active_record = class_double("ActiveRecord::Base")
+    allow(fake_active_record).to receive(:connection).and_raise(ActiveRecord::NoDatabaseError)
   end
 
   def contain_models_inherit_from


### PR DESCRIPTION
This assumes that if we can't connect to the database, then it probably
hasn't been created. And, if it hasn't been created, then the users
table probably doesn't exist. So we should generate a migration to
create the table.

Resolves #737