### PR TITLE
Remove unused method PasswordsController#url_after_create

### DIFF
--- a/app/controllers/clearance/passwords_controller.rb
+++ b/app/controllers/clearance/passwords_controller.rb
@@ -116,10 +116,6 @@ class Clearance::PasswordsController < Clearance::BaseController
       default: t('flashes.failure_after_update'))
   end
 
-  def url_after_create
-    sign_in_url
-  end
-
   def url_after_update
     Clearance.configuration.redirect_url
   end


### PR DESCRIPTION
[This commit](https://github.com/thoughtbot/clearance/commit/5e107f6695461baa006cb03ed548255ecddd5a7c) changed the behavior to show a message instead of redirecting after changing the password, so the `url_after_create` method became unused.