### PR TITLE
Updated information about custom layouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,12 +226,14 @@ $ rails generate clearance:views
 
 By default, Clearance uses your application's default layout. If you would like
 to change the layout that Clearance uses when rendering its views, simply
-specify the layout in an initializer.
+specify the layout in the `config/application.rb`
 
 ```ruby
-Clearance::PasswordsController.layout "my_passwords_layout"
-Clearance::SessionsController.layout "my_sessions_layout"
-Clearance::UsersController.layout "my_admin_layout"
+config.to_prepare do
+  Clearance::PasswordsController.layout "my_passwords_layout"
+  Clearance::SessionsController.layout "my_sessions_layout"
+  Clearance::UsersController.layout "my_admin_layout"
+end
 ```
 
 ### Translations


### PR DESCRIPTION
Setting the custom layout inside an initialiser does not work. Putting it in
your config/application.rb and then inside a `to_prepare` block does.

Fixes: #719