### PR TITLE
Proposal: Making [ActionMailer::Base] an optional dependancy

### DIFF
--- a/app/controllers/clearance/passwords_controller.rb
+++ b/app/controllers/clearance/passwords_controller.rb
@@ -58,13 +58,7 @@ class Clearance::PasswordsController < Clearance::BaseController
   private
 
   def deliver_email(user)
-    mail = ::ClearanceMailer.change_password(user)
-
-    if mail.respond_to?(:deliver_later)
-      mail.deliver_later
-    else
-      mail.deliver
-    end
+    Clearance.configuration.password_reset_mailer.call(user)
   end
 
   def password_reset_params

--- a/app/mailers/clearance_mailer.rb
+++ b/app/mailers/clearance_mailer.rb
@@ -1,13 +1,15 @@
-class ClearanceMailer < ActionMailer::Base
-  def change_password(user)
-    @user = user
-    mail(
-      from: Clearance.configuration.mailer_sender,
-      to: @user.email,
-      subject: I18n.t(
-        :change_password,
-        scope: [:clearance, :models, :clearance_mailer]
-      ),
-    )
+if defined?(ActionMailer::Base)
+  class ClearanceMailer < ActionMailer::Base
+    def change_password(user)
+      @user = user
+      mail(
+        from: Clearance.configuration.mailer_sender,
+        to: @user.email,
+        subject: I18n.t(
+          :change_password,
+          scope: [:clearance, :models, :clearance_mailer]
+        ),
+      )
+    end
   end
 end

--- a/lib/clearance/configuration.rb
+++ b/lib/clearance/configuration.rb
@@ -90,6 +90,8 @@ module Clearance
     # @return [ActiveRecord::Base]
     attr_accessor :user_model
 
+    attr_accessor :password_reset_mailer
+
     def initialize
       @allow_sign_up = true
       @cookie_expiration = ->(cookies) { 1.year.from_now.utc }
@@ -103,6 +105,7 @@ module Clearance
       @rotate_csrf_on_sign_in = nil
       @secure_cookie = false
       @sign_in_guards = []
+      @password_reset_mailer = ->(user) { ClearanceMailer.change_password(user).deliver_later }
     end
 
     def user_model


### PR DESCRIPTION
We currently have no requirement for ActionMailer in our app, and like to run as lean a stack as possible – requiring components independently rather than using `Rails.all`. 

Unfortunately though, because eager loading, using Clearance requires that we also include ActionMailer – even though we're sending all our mail through Mandrill.

I would like to propose that we soften the dependency on ActionMailer and also make the API for subbing out the mailer part of Clearance's config.

Happy to do the work to get this production ready, but want to float the idea before going too far down the rabbit hole. 