### PR TITLE
Correct typos in warning message

### DIFF
--- a/lib/clearance/configuration.rb
+++ b/lib/clearance/configuration.rb
@@ -163,13 +163,13 @@ module Clearance
     def rotate_csrf_on_sign_in?
       if rotate_csrf_on_sign_in.nil?
         warn <<-EOM.squish
-          Clearance's `rotate_csrf_on_sign_in` configration setting is unset and
+          Clearance's `rotate_csrf_on_sign_in` configuration setting is unset and
           will be treated as `false`. Setting this value to `true` is
           recommended to avoid session fixation attacks and will be the default
           in Clearance 2.0. It is recommended that you opt-in to this setting
           now and test your application. To silence this warning, set
           `rotate_csrf_on_sign_in` to `true` or `false` in Clearance's
-          inializer.
+          initializer.
 
           For more information on session fixation, see:
             https://www.owasp.org/index.php/Session_fixation


### PR DESCRIPTION
After installing Clearance on an app and adding a user, received message
about 'rotate_csrf_on_sign_in' being unset. I noticed two simple typos.
This commit simply corrects these and no functional change.