### PR TITLE
Return authentication cookie only if authentication is performed

### DIFF
--- a/lib/clearance/rack_session.rb
+++ b/lib/clearance/rack_session.rb
@@ -21,7 +21,11 @@ module Clearance
       session = Clearance::Session.new(env)
       env[:clearance] = session
       response = @app.call(env)
-      session.add_cookie_to_headers response[1]
+
+      if session.authentication_successful?
+        session.add_cookie_to_headers response[1]
+      end
+
       response
     end
   end

--- a/lib/clearance/session.rb
+++ b/lib/clearance/session.rb
@@ -94,6 +94,13 @@ module Clearance
       ! signed_in?
     end
 
+    # True if a successful authentication has been performed
+    #
+    # @return [Boolean]
+    def authentication_successful?
+      !!@current_user
+    end
+
     private
 
     # @api private

--- a/spec/clearance/rack_session_spec.rb
+++ b/spec/clearance/rack_session_spec.rb
@@ -11,6 +11,8 @@ describe Clearance::RackSession do
     env = Rack::MockRequest.env_for('/')
     expected_session = "the session"
     allow(expected_session).to receive(:add_cookie_to_headers)
+    allow(expected_session).to receive(:authentication_successful?).
+      and_return(true)
     allow(Clearance::Session).to receive(:new).
       with(env).
       and_return(expected_session)

--- a/spec/dummy/app/controllers/application_controller.rb
+++ b/spec/dummy/app/controllers/application_controller.rb
@@ -8,4 +8,12 @@ class ApplicationController < ActionController::Base
       render text: "", layout: "application"
     end
   end
+
+  def static_endpoint
+    if params[:use_current_user]
+      current_user # Just trigger the authentication
+    end
+
+    head :ok
+  end
 end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -1,3 +1,4 @@
 Rails.application.routes.draw do
   root to: "application#show"
+  get "/static-endpoint", to: "application#static_endpoint", as: :static_endpoint
 end

--- a/spec/requests/authentication_cookie_spec.rb
+++ b/spec/requests/authentication_cookie_spec.rb
@@ -1,0 +1,21 @@
+require "spec_helper"
+
+describe "Authentication cookie" do
+  it "is not returned if the request does not authenticate" do
+    user = create(:user, password: "password")
+
+    post session_path, session: { email: user.email, password: "password" }
+
+    get static_endpoint_path
+    expect(headers["Set-Cookie"]).to be_nil
+  end
+
+  it "is returned if the request does authentication" do
+    user = create(:user, password: "password")
+
+    post session_path, session: { email: user.email, password: "password" }
+
+    get static_endpoint_path(use_current_user: true)
+    expect(headers["Set-Cookie"]).to match(/remember_token=/)
+  end
+end


### PR DESCRIPTION
It's not safe to unconditionally write the authentication cookie on
every response. If the application chooses to use http cache on a given
endpoint, and the first hit to that endpoint is performed by an
authenticated user, its cookie will be cached and reused as a caned
response for any other incoming request.

The authentication cookie should be set only if the application has used
authentication during this request.