### PR TITLE
Fix password related issue for old/new token

### DIFF
--- a/app/controllers/clearance/passwords_controller.rb
+++ b/app/controllers/clearance/passwords_controller.rb
@@ -78,7 +78,7 @@ class Clearance::PasswordsController < Clearance::BaseController
 
   def find_user_by_id_and_confirmation_token
     user_param = Clearance.configuration.user_id_parameter
-    token = session[:password_reset_token] || params[:token]
+    token = params[:token] || session[:password_reset_token]
 
     Clearance.configuration.user_model.
       find_by_id_and_confirmation_token params[user_param], token.to_s

--- a/spec/controllers/passwords_controller_spec.rb
+++ b/spec/controllers/passwords_controller_spec.rb
@@ -99,6 +99,19 @@ describe Clearance::PasswordsController do
         expect(flash.now[:notice]).to match(/double check the URL/i)
       end
     end
+
+    context "old token in session and recent token in params" do
+      it "updates password reset session and redirect to edit page" do
+        user = create(:user, :with_forgotten_password)
+        request.session[:password_reset_token] = user.confirmation_token
+
+        user.forgot_password!
+        get :edit, user_id: user.id, token: user.reload.confirmation_token
+
+        expect(response).to redirect_to(edit_user_password_url(user))
+        expect(session[:password_reset_token]).to eq(user.confirmation_token)
+      end
+    end
   end
 
   describe "#update" do


### PR DESCRIPTION
Recently, to prevent password reset token via HTTP, there was an update to store the reset token in session and then redirect to the same edit page without token in the params, this works great but the way we find user introduced a new issue like 749

If the user requests a password reset and click on that link and for some reason that reset was unsuccessful and then the user request another link then it does not work and it keeps sending the user to the `password/new` page again and again.

Why is that happening?

The password `#edit`, and `#update` actions have before filter to ensure the token is valid for an existing user, and in the underneath `ensure_existing_user` is trying to find a user by the session token/parameter token.

But it gives precedence to the session token first and in above scenario, although the user has a new token in the URL, but the session still holds the old token which is not valid anymore and that creates the indefinite loop.

This commit adds a little tweak by switching the order and when a URL contains the `token` parameter then it updates the session reset token and then redirect to the same edit page. This way it updates the session & everything else stays same

Fixes: #749