### PR TITLE
Fix build issues on 1.9.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,10 @@ matrix:
     - rvm: 2.3.0
       gemfile: gemfiles/rails32.gemfile
 
+before_install:
+  - gem update --system
+  - gem update bundler
+
 install:
   - "bin/setup"
 


### PR DESCRIPTION
I'm not entirely certain what the underlying issue is here, but we've
started getting the following error when setting up the project on CI
under 1.9.3 Some cursory googling shows that updating rubygems and/or
bunder should fix this.

```
NoMethodError: undefined method `spec' for nil:NilClass
An error occurred while installing clearance (1.16.0), and Bundler cannot
continue.
Make sure that `gem install clearance -v '1.16.0'` succeeds before bundling.
```