### PR TITLE
Allow fragment in `session[:return_to]` value

### DIFF
--- a/lib/clearance/authorization.rb
+++ b/lib/clearance/authorization.rb
@@ -95,7 +95,7 @@ module Clearance
     def return_to
       if return_to_url
         uri = URI.parse(return_to_url)
-        "#{uri.path}?#{uri.query}".chomp('?')
+        "#{uri.path}?#{uri.query}".chomp("?") + "##{uri.fragment}".chomp("#")
       end
     end
 

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -54,15 +54,34 @@ describe Clearance::SessionsController do
     end
 
     context "with good credentials and a session return url" do
-      before do
-        @user = create(:user)
-        @return_url = "/url_in_the_session?foo=bar"
-        @request.session[:return_to] = @return_url
-        post :create, session: { email: @user.email, password: @user.password }
+      it "redirects to the return URL maintaining query and fragment" do
+        user = create(:user)
+        return_url = "/url_in_the_session?foo=bar#baz"
+        request.session[:return_to] = return_url
+
+        post :create, session: { email: user.email, password: user.password }
+
+        should redirect_to(return_url)
       end
 
-      it "redirects to the return URL" do
-        should redirect_to(@return_url)
+      it "redirects to the return URL maintaining query without fragment" do
+        user = create(:user)
+        return_url = "/url_in_the_session?foo=bar"
+        request.session[:return_to] = return_url
+
+        post :create, session: { email: user.email, password: user.password }
+
+        should redirect_to(return_url)
+      end
+
+      it "redirects to the return URL without query or fragment" do
+        user = create(:user)
+        return_url = "/url_in_the_session"
+        request.session[:return_to] = return_url
+
+        post :create, session: { email: user.email, password: user.password }
+
+        should redirect_to(return_url)
       end
     end
   end


### PR DESCRIPTION
Under ordinary operation, clearance automatically sets the
`session[:return_to]` value when a non-signed-in user hits a protected
page. By spec, this value won't have a fragment because the fragment is
never sent to the server (it's all handled client side).

However, it's possible that developers will want to manually set a
`return_to` value that has a fragment. Prior to this change, this would
always be stripped out. This change fixes that by preserving the
fragment when it is present and eliminating any dangling `#`s.

Closes #733