### PR TITLE
Updates to use `scope` and to use `to:` in routing generator template 

### DIFF
--- a/lib/generators/clearance/routes/templates/routes.rb
+++ b/lib/generators/clearance/routes/templates/routes.rb
@@ -4,7 +4,7 @@
 
     resources :users, only: [:create] do
       resource :password, controller: :passwords,
-        only: [:create, :edit, :update]
+                          only: [:create, :edit, :update]
     end
 
     get "/sign_in", to: "sessions#new", as: "sign_in"

--- a/lib/generators/clearance/routes/templates/routes.rb
+++ b/lib/generators/clearance/routes/templates/routes.rb
@@ -1,9 +1,9 @@
   scope module: :clearance do
-    resources :passwords, only: [:create, :new]
-    resource :session, controller: :sessions, only: [:create]
+    resources :passwords, only: %i(create new)
+    resource :session, controller: :sessions, only: %i(create)
 
     resources :users, only: [:create] do
-      resource :password, controller: :passwords, only: [:create, :edit, :update]
+      resource :password, controller: :passwords, only: %i(create edit update)
     end
 
     get "/sign_in", to: "sessions#new", as: "sign_in"

--- a/lib/generators/clearance/routes/templates/routes.rb
+++ b/lib/generators/clearance/routes/templates/routes.rb
@@ -10,3 +10,4 @@
     delete "/sign_out", to: "sessions#destroy", as: "sign_out"
     get "/sign_up", to: "users#new", as: "sign_up"
   end
+

--- a/lib/generators/clearance/routes/templates/routes.rb
+++ b/lib/generators/clearance/routes/templates/routes.rb
@@ -1,12 +1,12 @@
-  resources :passwords, controller: "clearance/passwords", only: [:create, :new]
-  resource :session, controller: "clearance/sessions", only: [:create]
+  scope module: :clearance do
+    resources :passwords, only: [:create, :new]
+    resource :session, controller: :sessions, only: [:create]
 
-  resources :users, controller: "clearance/users", only: [:create] do
-    resource :password,
-      controller: "clearance/passwords",
-      only: [:create, :edit, :update]
+    resources :users, only: [:create] do
+      resource :password, controller: :passwords, only: [:create, :edit, :update]
+    end
+
+    get "/sign_in", to: "sessions#new", as: "sign_in"
+    delete "/sign_out", to: "sessions#destroy", as: "sign_out"
+    get "/sign_up", to: "users#new", as: "sign_up"
   end
-
-  get "/sign_in" => "clearance/sessions#new", as: "sign_in"
-  delete "/sign_out" => "clearance/sessions#destroy", as: "sign_out"
-  get "/sign_up" => "clearance/users#new", as: "sign_up"

--- a/lib/generators/clearance/routes/templates/routes.rb
+++ b/lib/generators/clearance/routes/templates/routes.rb
@@ -3,7 +3,8 @@
     resource :session, controller: :sessions, only: [:create]
 
     resources :users, only: [:create] do
-      resource :password, controller: :passwords, only: [:create, :edit, :update]
+      resource :password, controller: :passwords,
+        only: [:create, :edit, :update]
     end
 
     get "/sign_in", to: "sessions#new", as: "sign_in"

--- a/lib/generators/clearance/routes/templates/routes.rb
+++ b/lib/generators/clearance/routes/templates/routes.rb
@@ -1,9 +1,9 @@
   scope module: :clearance do
-    resources :passwords, only: %i(create new)
-    resource :session, controller: :sessions, only: %i(create)
+    resources :passwords, only: [:create, :new]
+    resource :session, controller: :sessions, only: [:create]
 
     resources :users, only: [:create] do
-      resource :password, controller: :passwords, only: %i(create edit update)
+      resource :password, controller: :passwords, only: [:create, :edit, :update]
     end
 
     get "/sign_in", to: "sessions#new", as: "sign_in"

--- a/spec/generators/clearance/routes/routes_generator_spec.rb
+++ b/spec/generators/clearance/routes/routes_generator_spec.rb
@@ -15,7 +15,7 @@ describe Clearance::Generators::RoutesGenerator, :generator do
     expect(initializer).to contain("config.routes = false")
     expect(routes).to have_correct_syntax
     expect(routes).to contain(
-      'get "/sign_in" => "clearance/sessions#new", as: "sign_in"'
+      'get "/sign_in", to: "sessions#new", as: "sign_in"'
     )
   end
 end

--- a/spec/generators/clearance/routes/routes_generator_spec.rb
+++ b/spec/generators/clearance/routes/routes_generator_spec.rb
@@ -15,7 +15,7 @@ describe Clearance::Generators::RoutesGenerator, :generator do
     expect(initializer).to contain("config.routes = false")
     expect(routes).to have_correct_syntax
     expect(routes).to contain(
-      'get "/sign_in", to: "sessions#new", as: "sign_in"'
+      'get "/sign_in", to: "sessions#new", as: "sign_in"',
     )
   end
 end


### PR DESCRIPTION
Currently the routings generated with `rails generate clearance:routes` has a few outdated and redundant syntaxes. This PR updates two following things.
- Abandons `clearance/xxx` syntax and use `scope module: :clearance do ... end`
- Removes old hash-rockets and use `to: xxx` syntax.