### PR TITLE
Do not depend on Rails

### DIFF
--- a/clearance.gemspec
+++ b/clearance.gemspec
@@ -5,7 +5,9 @@ require 'date'
 Gem::Specification.new do |s|
   s.add_dependency 'bcrypt'
   s.add_dependency 'email_validator', '~> 1.4'
-  s.add_dependency 'rails', '>= 3.1'
+  s.add_dependency 'railties', '>= 3.1'
+  s.add_dependency 'actionpack', '>= 3.1'
+  s.add_dependency 'activerecord', '>= 3.1'
   s.authors = [
     'Dan Croak',
     'Eugene Bolshakov',


### PR DESCRIPTION
Rails comes with Actioncable and all sorts of other stuff which not everyone might want to have installed. It's better to depend on the parts of Rails that are actually required by Clearance. Otherwise everyone is forced to install all parts of Rails instead of just the parts that are necessary.