### PR TITLE
write a single cookie with the correct options

### DIFF
--- a/lib/clearance/session.rb
+++ b/lib/clearance/session.rb
@@ -15,11 +15,11 @@ module Clearance
     #
     # @return [void]
     def add_cookie_to_headers(headers)
-      if cookie_options[:value].present?
+      if current_user&.remember_token
         Rack::Utils.set_cookie_header!(
           headers,
           remember_token_cookie,
-          cookie_options,
+          cookie_options.merge(value: current_user.remember_token),
         )
       end
     end
@@ -53,9 +53,7 @@ module Clearance
       @current_user = user
       status = run_sign_in_stack
 
-      if status.success?
-        cookies[remember_token_cookie] = user && user.remember_token
-      else
+      if !status.success?
         @current_user = nil
       end
 
@@ -158,7 +156,6 @@ module Clearance
         httponly: Clearance.configuration.httponly,
         path: Clearance.configuration.cookie_path,
         secure: Clearance.configuration.secure_cookie,
-        value: remember_token,
       }
     end
   end

--- a/spec/clearance/session_spec.rb
+++ b/spec/clearance/session_spec.rb
@@ -191,6 +191,7 @@ describe Clearance::Session do
         expiration = -> { Time.now }
         with_custom_expiration expiration do
           session = Clearance::Session.new(env_without_remember_token)
+          session.sign_in user
           allow(session).to receive(:warn)
           session.add_cookie_to_headers headers
 

--- a/spec/controllers/passwords_controller_spec.rb
+++ b/spec/controllers/passwords_controller_spec.rb
@@ -159,7 +159,6 @@ describe Clearance::PasswordsController do
         )
 
         expect(response).to redirect_to(Clearance.configuration.redirect_url)
-        expect(cookies[:remember_token]).to be_present
       end
     end
 

--- a/spec/requests/cookie_options_spec.rb
+++ b/spec/requests/cookie_options_spec.rb
@@ -1,0 +1,61 @@
+require "spec_helper"
+
+describe "cookie options" do
+  before do
+    Clearance.configuration.httponly = httponly
+  end
+
+  context "when httponly config value false" do
+    let(:httponly) { false }
+    describe "sign in" do
+      before do
+        get sign_in_path
+        user = create(:user, password: "password")
+
+        post session_path,
+             params: { session: { email: user.email, password: "password" } }
+        @remember_token_cookies = headers["Set-Cookie"].
+          split("\n").
+          select { |v| v =~ /^remember_token/ }
+      end
+
+      it "should have one remember_token cookie" do
+        expect(@remember_token_cookies.length).to(
+          eq(1),
+          "expected one 'remember_token' cookie:\n#{@remember_token_cookies}",
+        )
+      end
+
+      it "should not have the httponly flag set" do
+        expect(@remember_token_cookies.last).to_not match(/httponly/i)
+      end
+    end
+  end
+
+  context "when httponly config value true" do
+    let(:httponly) { true }
+    describe "sign in" do
+      before do
+        get sign_in_path
+        user = create(:user, password: "password")
+
+        post session_path,
+             params: { session: { email: user.email, password: "password" } }
+        @remember_token_cookies = headers["Set-Cookie"].
+          split("\n").
+          select { |v| v =~ /^remember_token/ }
+      end
+
+      it "should have one remember_token cookie" do
+        expect(@remember_token_cookies.length).to(
+          eq(1),
+          "expected one 'remember_token' cookie:\n#{@remember_token_cookies}",
+        )
+      end
+
+      it "should have the httponly flag set" do
+        expect(@remember_token_cookies.last).to match(/httponly/i)
+      end
+    end
+  end
+end

--- a/spec/requests/token_expiration_spec.rb
+++ b/spec/requests/token_expiration_spec.rb
@@ -1,0 +1,66 @@
+require "spec_helper"
+
+describe "token expiration" do
+  describe "after sign-in" do
+    before do
+      get sign_in_path
+      user = create(:user, password: "password")
+
+      post session_path,
+           params: { session: { email: user.email, password: "password" } }
+      @remember_token_cookies = headers["Set-Cookie"].
+        split("\n").
+        select { |v| v =~ /^remember_token/ }
+    end
+
+    it "should have a remember_token cookie with an expiration of <>" do
+      cookie_hash = cookie_to_hash(@remember_token_cookies.last)
+      expect(cookie_hash["expires"]).to(
+        be_between(1.years.from_now - 1.second, 1.years.from_now),
+      )
+    end
+  end
+
+  describe "after sign-in and another request" do
+    before do
+      get sign_in_path
+      user = create(:user, password: "password")
+
+      post session_path,
+           params: { session: { email: user.email, password: "password" } }
+      @first_remember_token_cookies = headers["Set-Cookie"].
+        split("\n").
+        select { |v| v =~ /^remember_token/ }
+
+      sleep 2
+      get root_path
+      @second_remember_token_cookies = headers["Set-Cookie"].
+        split("\n").
+        select { |v| v =~ /^remember_token/ }
+    end
+
+    it "sets a new remember_token on every request with updated expiration" do
+      expect(@second_remember_token_cookies.last).to(
+        be,
+        "remember token wasn't set on second request",
+      )
+
+      first_expiration =
+        cookie_to_hash(@first_remember_token_cookies.last)["expires"]
+      second_expiration =
+        cookie_to_hash(@second_remember_token_cookies.last)["expires"]
+      expect(second_expiration).to be > first_expiration
+    end
+  end
+
+  def cookie_to_hash(cookie_string)
+    elements = cookie_string.split(/;\s+/)
+    pairs = elements.map { |ele| ele.split("=") }
+
+    name = pairs[0][0]
+    value = pairs[0][1]
+    h = Hash[pairs].merge("name" => name, "value" => value)
+    h["expires"] = Time.parse(h["expires"])
+    h
+  end
+end


### PR DESCRIPTION
  ### Problem: httponly setting has no affect
I set `Clearance.configuration.httponly = true` but I noticed that executing `document.cookie` in Chrome's inspector still contained `remember_token`, then I realized that clearance was setting this cookie twice, once with `httponly`, and once without it.

Here's a spec that demonstrates the problem:
https://github.com/CasperSleep/clearance/commit/6f930bc235ed70f7b26750157ef66aaf7d89b30e

```
Failures:

  1) cookie options when httponly config value true sign in should have one remember_token cookie
     Failure/Error: expect(@remember_token_cookies.length).to eq(1), "expected one 'remember_token' cookie:\n#{@remember_token_cookies}"

       expected one 'remember_token' cookie:
       ["remember_token=1b3f09cead4c3ba39bed8ac0831837b0ea52a7b1; path=/; expires=Sat, 05 Jan 2019 18:04:16 -0000; HttpOnly", "remember_token=1b3f09cead4c3ba39bed8ac0831837b0ea52a7b1; path=/"]
     # /Users/dholdren/Dropbox (Personal)/third_party/clearance/spec/requests/cookie_options_spec.rb:41:in `block (4 levels) in <top (required)>'

  2) cookie options when httponly config value true sign in should have the httponly flag set
     Failure/Error: expect(@remember_token_cookies.last).to match(/httponly/i)

       expected "remember_token=fe6e5ed40284f7a724387fd25a2b2524918a9279; path=/" to match /httponly/i
       Diff:
       @@ -1,2 +1,2 @@
       -/httponly/i
       +"remember_token=fe6e5ed40284f7a724387fd25a2b2524918a9279; path=/"

     # /Users/dholdren/Dropbox (Personal)/third_party/clearance/spec/requests/cookie_options_spec.rb:45:in `block (4 levels) in <top (required)>'

  3) cookie options when httponly config value false sign in should have one remember_token cookie
     Failure/Error: expect(@remember_token_cookies.length).to eq(1), "expected one 'remember_token' cookie:\n#{@remember_token_cookies}"

       expected one 'remember_token' cookie:
       ["remember_token=5323f9bdb472031440d20a7283672d6590f856e8; path=/; expires=Sat, 05 Jan 2019 18:04:16 -0000", "remember_token=5323f9bdb472031440d20a7283672d6590f856e8; path=/"]
     # /Users/dholdren/Dropbox (Personal)/third_party/clearance/spec/requests/cookie_options_spec.rb:20:in `block (4 levels) in <top (required)>'

Finished in 0.39193 seconds (files took 1.16 seconds to load)
4 examples, 3 failures

Failed examples:

rspec /Users/dholdren/Dropbox (Personal)/third_party/clearance/spec/requests/cookie_options_spec.rb:40 # cookie options when httponly config value true sign in should have one remember_token cookie
rspec /Users/dholdren/Dropbox (Personal)/third_party/clearance/spec/requests/cookie_options_spec.rb:44 # cookie options when httponly config value true sign in should have the httponly flag set
rspec /Users/dholdren/Dropbox (Personal)/third_party/clearance/spec/requests/cookie_options_spec.rb:19 # cookie options when httponly config value false sign in should have one remember_token cookie
```

### Solution

- removed `add_cookie_to_headers` in Rack middleware
- modified the cookie that is set after login to have the correct options
- reworked all the tests that called `add_cookie_to_headers` explicitly