### PR TITLE
remove rails dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,9 +2,12 @@ PATH
   remote: .
   specs:
     clearance (1.16.1)
+      actionmailer (>= 3.1)
+      activemodel (>= 3.1)
+      activerecord (>= 3.1)
       bcrypt
       email_validator (~> 1.4)
-      rails (>= 3.1)
+      railties (>= 3.1)
 
 GEM
   remote: https://rubygems.org/
@@ -64,7 +67,6 @@ GEM
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
     coderay (1.1.1)
-    concurrent-ruby (1.0.5)
     database_cleaner (1.5.3)
     diff-lcs (1.2.5)
     email_validator (1.6.0)
@@ -99,17 +101,6 @@ GEM
     rack (1.6.5)
     rack-test (0.6.3)
       rack (>= 1.0)
-    rails (4.2.7.1)
-      actionmailer (= 4.2.7.1)
-      actionpack (= 4.2.7.1)
-      actionview (= 4.2.7.1)
-      activejob (= 4.2.7.1)
-      activemodel (= 4.2.7.1)
-      activerecord (= 4.2.7.1)
-      activesupport (= 4.2.7.1)
-      bundler (>= 1.3.0, < 2.0)
-      railties (= 4.2.7.1)
-      sprockets-rails
     rails-deprecated_sanitizer (1.0.3)
       activesupport (>= 4.2.0.alpha)
     rails-dom-testing (1.0.8)
@@ -144,13 +135,6 @@ GEM
     shoulda-matchers (2.8.0)
       activesupport (>= 3.0.0)
     slop (3.6.0)
-    sprockets (3.7.1)
-      concurrent-ruby (~> 1.0)
-      rack (> 1, < 3)
-    sprockets-rails (3.2.1)
-      actionpack (>= 4.0)
-      activesupport (>= 4.0)
-      sprockets (>= 3.0.0)
     sqlite3 (1.3.11)
     thor (0.19.4)
     thread_safe (0.3.5)

--- a/clearance.gemspec
+++ b/clearance.gemspec
@@ -5,7 +5,10 @@ require 'date'
 Gem::Specification.new do |s|
   s.add_dependency 'bcrypt'
   s.add_dependency 'email_validator', '~> 1.4'
-  s.add_dependency 'rails', '>= 3.1'
+  s.add_dependency 'railties', '>= 3.1'
+  s.add_dependency 'activemodel', '>= 3.1'
+  s.add_dependency 'activerecord', '>= 3.1'
+  s.add_dependency 'actionmailer', '>= 3.1'
   s.authors = [
     'Dan Croak',
     'Eugene Bolshakov',

--- a/lib/clearance/engine.rb
+++ b/lib/clearance/engine.rb
@@ -1,5 +1,5 @@
 require "clearance"
-require "rails"
+require "rails/engine"
 
 module Clearance
   # Makes Clearance behavior available to Rails apps on initialization. By using

--- a/lib/clearance/user.rb
+++ b/lib/clearance/user.rb
@@ -1,4 +1,5 @@
 require 'digest/sha1'
+require 'active_model'
 require 'email_validator'
 require 'clearance/token'
 


### PR DESCRIPTION
This removes the "rails" gem as a dependency of clearance, to enable clearance users to require individual rails components instead of forcing them all as dependencies.

What motivated me to do this was the desire to not include actioncable in my project.

Let me know what you think!