### PR TITLE
Allow user_parameter to be configurable.

### DIFF
--- a/lib/clearance/configuration.rb
+++ b/lib/clearance/configuration.rb
@@ -105,6 +105,11 @@ module Clearance
     # @return [Array<String>]
     attr_accessor :allowed_backdoor_environments
 
+    # The parameter for user routes. By default this is derived from the user
+    # model.
+    # @return [Symbol]
+    attr_accessor :user_parameter
+
     def initialize
       @allow_sign_up = true
       @allowed_backdoor_environments = ["test", "ci", "development"]
@@ -120,6 +125,7 @@ module Clearance
       @routes = true
       @secure_cookie = false
       @sign_in_guards = []
+      @user_parameter = nil
     end
 
     def user_model
@@ -149,7 +155,7 @@ module Clearance
     # In the default configuration, this is `user`.
     # @return [Symbol]
     def user_parameter
-      user_model.model_name.singular.to_sym
+      @user_parameter ||= user_model.model_name.singular.to_sym
     end
 
     # The name of foreign key parameter for the configured user model.

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -115,7 +115,14 @@ describe Clearance::Configuration do
   end
 
   describe "#user_parameter" do
-    it "returns the parameter key to use based on the user_model" do
+    context "when user_parameter is configured" do
+      it "returns the configured parameter" do
+        Clearance.configure { |config| config.user_parameter = :custom_param }
+        expect(Clearance.configuration.user_parameter).to eq :custom_param
+      end
+    end
+
+    it "returns the parameter key to use based on the user_model by default" do
       Account = Class.new(ActiveRecord::Base)
       Clearance.configure { |config| config.user_model = Account }
 


### PR DESCRIPTION
I created a subclass of User with scoping that restricts the login/password reset ability of certain users. But doing this, changes the url parameter used in specs.

For example, with `config.user_model = ClearanceUser`, the routes expect users/:clearance_user_id/password.

In order to maintain the routing/naming structure of user_password_path, I needed to be able to force the named parameter to `:user_id`.