### PR TITLE
Add support for Rails 5 ActionDispatch::IntegrationTest

### DIFF
--- a/lib/clearance/minitest.rb
+++ b/lib/clearance/minitest.rb
@@ -1,0 +1,19 @@
+require "clearance/testing/deny_access_matcher"
+require "clearance/testing/controller_helpers"
+
+ActionDispatch::IntegrationTest.extend Clearance::Testing::Matchers
+
+module Clearance
+  module Testing
+    module ControllerHelpers
+      def sign_in_as(user)
+        post session_url, params: { session: { email: user.email, password: user.password } }
+        user
+      end
+    end
+  end
+end
+
+class ActionDispatch::IntegrationTest
+  include Clearance::Testing::ControllerHelpers
+end


### PR DESCRIPTION
I'm not sure if this is the best approach, but I got it working on a Rails 5.1.x app.

The underlying problem is that in `ActionDispatch::IntegrationTest` a `request` object is not available before the request is made, unlike in old `ActionController::TestCase` ([link](https://github.com/rails/rails/blob/master/actionpack/lib/action_controller/test_case.rb#L269-L272)). In current Rails documentation, a test helper that sends a real request [is suggested](http://edgeguides.rubyonrails.org/testing.html#test-helpers), so by overriding `#sign_in_as` it can be fixed.

I don't think this PR is complete, since if session route name is changed it will raise an error, but I wanted to know first if this would be an acceptable approach.

An alternative workaround would be to set the request object as `ActionController::TestCase` does.