### PR TITLE
Add parent_controller option to configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Clearance.configure do |config|
   config.secure_cookie = false
   config.sign_in_guards = []
   config.user_model = User
+  config.parent_controller = ApplicationController
 end
 ```
 

--- a/app/controllers/clearance/base_controller.rb
+++ b/app/controllers/clearance/base_controller.rb
@@ -1,2 +1,1 @@
-class Clearance::BaseController < ApplicationController
-end
+Clearance::BaseController = Class.new(Clearance.configuration.parent_controller)

--- a/lib/clearance/configuration.rb
+++ b/lib/clearance/configuration.rb
@@ -90,6 +90,11 @@ module Clearance
     # @return [ActiveRecord::Base]
     attr_accessor :user_model
 
+    # The parent controller all Clearance controllers inherits from.
+    # Defaults to `::ApplicationController`.
+    # @return [ActionController::Base]
+    attr_writer :parent_controller
+
     def initialize
       @allow_sign_up = true
       @cookie_expiration = ->(cookies) { 1.year.from_now.utc }
@@ -107,6 +112,10 @@ module Clearance
 
     def user_model
       @user_model ||= ::User
+    end
+
+    def parent_controller
+      @parent_controller ||= ::ApplicationController
     end
 
     # Is the user sign up route enabled?

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -1,6 +1,8 @@
 require "spec_helper"
 
 describe Clearance::Configuration do
+  let(:config) { Clearance.configuration }
+
   context "when no user_model_name is specified" do
     it "defaults to User" do
       expect(Clearance.configuration.user_model).to eq ::User
@@ -13,6 +15,21 @@ describe Clearance::Configuration do
       Clearance.configure { |config| config.user_model = MyUser }
 
       expect(Clearance.configuration.user_model).to eq ::MyUser
+    end
+  end
+
+  context "when no parent_controller is specified" do
+    it "defaults to ApplicationController" do
+      expect(config.parent_controller).to eq ::ApplicationController
+    end
+  end
+
+  context "when a custom parent_controller is specified" do
+    it "is used instead of ApplicationController" do
+      AdminController = Class.new
+      Clearance.configure { |c| c.parent_controller = AdminController }
+
+      expect(config.parent_controller).to eq ::AdminController
     end
   end
 


### PR DESCRIPTION
Hi there!

We use `clearance` to authenticate admins in our application. For our purpose, we'll need to change the base class of `Clearance::BaseController` from `ApplicationController` to `Admin::ApplicationController`. Also, I saw the same issue #777.

So, I made the simple solution to this problem.