### PR TITLE
Allow BCrypt cost value to be configured

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       actionmailer (>= 3.1)
       activemodel (>= 3.1)
       activerecord (>= 3.1)
-      bcrypt
+      bcrypt (>= 3.1.1)
       email_validator (~> 1.4)
       railties (>= 3.1)
 

--- a/clearance.gemspec
+++ b/clearance.gemspec
@@ -3,7 +3,7 @@ require 'clearance/version'
 require 'date'
 
 Gem::Specification.new do |s|
-  s.add_dependency 'bcrypt'
+  s.add_dependency 'bcrypt', '>= 3.1.1'
   s.add_dependency 'email_validator', '~> 1.4'
   s.add_dependency 'railties', '>= 3.1'
   s.add_dependency 'activemodel', '>= 3.1'

--- a/lib/clearance/password_strategies/bcrypt.rb
+++ b/lib/clearance/password_strategies/bcrypt.rb
@@ -6,6 +6,9 @@ module Clearance
     # will perform) is automatically set to the minimum allowed value when
     # Rails is operating in the test environment and the default cost in all
     # other envionments. This provides a speed boost in tests.
+    #
+    # To set your own cost value, use an inititalizer:
+    # `BCrypt::Engine.cost = 12`
     module BCrypt
       require 'bcrypt'
 
@@ -19,17 +22,19 @@ module Clearance
         @password = new_password
 
         if new_password.present?
-          cost = if defined?(::Rails) && ::Rails.env.test?
-                   ::BCrypt::Engine::MIN_COST
-                 else
-                   ::BCrypt::Engine::DEFAULT_COST
-                 end
-
           self.encrypted_password = ::BCrypt::Password.create(
             new_password,
             cost: cost,
           )
         end
+      end
+
+      def cost
+        if defined?(::Rails) && ::Rails.env.test?
+          ::BCrypt::Engine::MIN_COST
+        end
+        # Otherwise return nil, so that the cost stored in BCrypt
+        # (or its default) is used
       end
     end
   end

--- a/lib/clearance/password_strategies/bcrypt.rb
+++ b/lib/clearance/password_strategies/bcrypt.rb
@@ -7,7 +7,7 @@ module Clearance
     # Rails is operating in the test environment and the default cost in all
     # other envionments. This provides a speed boost in tests.
     #
-    # To set your own cost value, use an inititalizer:
+    # To set your own cost value, use an initializer:
     # `BCrypt::Engine.cost = 12`
     module BCrypt
       require 'bcrypt'

--- a/lib/clearance/password_strategies/bcrypt.rb
+++ b/lib/clearance/password_strategies/bcrypt.rb
@@ -2,18 +2,13 @@ module Clearance
   module PasswordStrategies
     # Uses BCrypt to authenticate users and store encrypted passwords.
     #
-    # The BCrypt cost (the measure of how many key expansion iterations BCrypt
-    # will perform) is automatically set to the minimum allowed value when
-    # Rails is operating in the test environment and the default cost in all
-    # other envionments. This provides a speed boost in tests.
-    #
-  # BCrypt has a `cost` argument which determines how computationally expensive
-  # the hash is to calculate. The higher the cost, the harder it is for
-  # attackers to crack passwords even if they posess a database dump of the
-  # encrypted passwords. Clearance uses the `bcrypt-ruby` default cost except in 
-  # the test environment, where it uses the minimum cost value for speed. If you
-  # wish to increase the cost over the default, you can do so by setting a
-  # higher cost in an initializer: 
+    # BCrypt has a `cost` argument which determines how computationally
+    # expensive the hash is to calculate. The higher the cost, the harder it is
+    # for attackers to crack passwords even if they posess a database dump of
+    # the encrypted passwords. Clearance uses the `bcrypt-ruby` default cost
+    # except in the test environment, where it uses the minimum cost value for
+    # speed. If you wish to increase the cost over the default, you can do so
+    # by setting a higher cost in an initializer:
     # `BCrypt::Engine.cost = 12`
     module BCrypt
       require 'bcrypt'
@@ -30,7 +25,7 @@ module Clearance
         if new_password.present?
           self.encrypted_password = ::BCrypt::Password.create(
             new_password,
-            cost: cost,
+            cost: cost
           )
         end
       end

--- a/lib/clearance/password_strategies/bcrypt.rb
+++ b/lib/clearance/password_strategies/bcrypt.rb
@@ -32,6 +32,8 @@ module Clearance
       def cost
         if defined?(::Rails) && ::Rails.env.test?
           ::BCrypt::Engine::MIN_COST
+        else
+          ::BCrypt::Engine.cost
         end
         # Otherwise return nil, so that the cost stored in BCrypt
         # (or its default) is used

--- a/lib/clearance/password_strategies/bcrypt.rb
+++ b/lib/clearance/password_strategies/bcrypt.rb
@@ -25,7 +25,7 @@ module Clearance
         if new_password.present?
           self.encrypted_password = ::BCrypt::Password.create(
             new_password,
-            cost: cost
+            cost: cost,
           )
         end
       end

--- a/spec/password_strategies/bcrypt_spec.rb
+++ b/spec/password_strategies/bcrypt_spec.rb
@@ -18,11 +18,11 @@ describe Clearance::PasswordStrategies::BCrypt do
       allow(Rails).to receive(:env).
         and_return(ActiveSupport::StringInquirer.new("production"))
 
-      result = model_instance.password = password
+      model_instance.password = password
 
       expect(BCrypt::Password).to have_received(:create).with(
         password,
-        cost: nil
+        cost: nil,
       )
     end
 
@@ -32,7 +32,8 @@ describe Clearance::PasswordStrategies::BCrypt do
     end
 
     it "uses the default BCrypt cost value implicitly" do
-      expect(BCrypt::Password.create(password, cost: nil).cost).to eq BCrypt::Engine::DEFAULT_COST
+      cost = BCrypt::Password.create(password, cost: nil).cost
+      expect(cost).to eq BCrypt::Engine::DEFAULT_COST
     end
 
     it "encrypts with BCrypt using minimum cost in test environment" do
@@ -50,7 +51,7 @@ describe Clearance::PasswordStrategies::BCrypt do
     def stub_bcrypt_password
       allow(BCrypt::Password).to receive(:create).and_return(encrypted_password)
     end
-    
+
     def stub_bcrypt_cost(cost)
       allow(BCrypt::Engine).to receive(:cost).and_return(cost)
     end

--- a/spec/password_strategies/bcrypt_spec.rb
+++ b/spec/password_strategies/bcrypt_spec.rb
@@ -18,12 +18,21 @@ describe Clearance::PasswordStrategies::BCrypt do
       allow(Rails).to receive(:env).
         and_return(ActiveSupport::StringInquirer.new("production"))
 
-      model_instance.password = password
+      result = model_instance.password = password
 
       expect(BCrypt::Password).to have_received(:create).with(
         password,
-        cost: ::BCrypt::Engine::DEFAULT_COST
+        cost: nil
       )
+    end
+
+    it "uses an explicity configured BCrypt cost" do
+      stub_bcrypt_cost(8)
+      expect(BCrypt::Password.create(password, cost: nil).cost).to eq 8
+    end
+
+    it "uses the default BCrypt cost value implicitly" do
+      expect(BCrypt::Password.create(password, cost: nil).cost).to eq BCrypt::Engine::DEFAULT_COST
     end
 
     it "encrypts with BCrypt using minimum cost in test environment" do
@@ -40,6 +49,10 @@ describe Clearance::PasswordStrategies::BCrypt do
 
     def stub_bcrypt_password
       allow(BCrypt::Password).to receive(:create).and_return(encrypted_password)
+    end
+    
+    def stub_bcrypt_cost(cost)
+      allow(BCrypt::Engine).to receive(:cost).and_return(cost)
     end
 
     def encrypted_password

--- a/spec/password_strategies/bcrypt_spec.rb
+++ b/spec/password_strategies/bcrypt_spec.rb
@@ -12,7 +12,7 @@ describe Clearance::PasswordStrategies::BCrypt do
       expect(model_instance.encrypted_password).to eq encrypted_password
     end
 
-    it "encrypts with BCrypt using default cost in non test environments" do
+    it "encrypts with BCrypt using default cost in non-test environments" do
       stub_bcrypt_password
       model_instance = fake_model_with_bcrypt_strategy
       allow(Rails).to receive(:env).
@@ -22,7 +22,7 @@ describe Clearance::PasswordStrategies::BCrypt do
 
       expect(BCrypt::Password).to have_received(:create).with(
         password,
-        cost: nil,
+        cost: ::BCrypt::Engine::DEFAULT_COST,
       )
     end
 


### PR DESCRIPTION
The default value of 10 is no longer sufficient for some applications.
To calculate a cost factor based on how much time you'd like password
hashing to take (in milliseconds), see `BCrypt::Engine.calibrate(ms)`

To set your own cost value, use an inititalizer:
`BCrypt::Engine.cost = 12`