### PR TITLE
Override default `:notice` flash key

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Clearance.configure do |config|
   config.secure_cookie = false
   config.sign_in_guards = []
   config.user_model = User
+  config.flash_error_key = :notice
 end
 ```
 
@@ -127,6 +128,28 @@ should change the `mailer_sender` default, used in the email's "from" header:
 Clearance.configure do |config|
   config.mailer_sender = "reply@example.com"
 end
+```
+
+### Flash Messages
+
+The flash key used for displaying errors can be set using the `flash_error_key` config option.
+
+An example bootstrap setup might look like this:
+
+```ruby
+Clearance.configure do |config|
+  config.flash_error_key = :danger
+end
+```
+
+With the following code in the layout:
+
+```ruby
+<% flash.each do |key, value| %>
+  <div class="alert alert-<%= key %>">
+    <%= value %>
+  </div>
+<% end %>
 ```
 
 ### Integrating with Rack Applications

--- a/app/controllers/clearance/passwords_controller.rb
+++ b/app/controllers/clearance/passwords_controller.rb
@@ -105,13 +105,15 @@ class Clearance::PasswordsController < Clearance::BaseController
   end
 
   def flash_failure_when_forbidden
-    flash.now[:notice] = translate(:forbidden,
+    flash_error_key = Clearance.configuration.flash_error_key
+    flash.now[flash_error_key] = translate(:forbidden,
       scope: [:clearance, :controllers, :passwords],
       default: t('flashes.failure_when_forbidden'))
   end
 
   def flash_failure_after_update
-    flash.now[:notice] = translate(:blank_password,
+    flash_error_key = Clearance.configuration.flash_error_key
+    flash.now[flash_error_key] = translate(:blank_password,
       scope: [:clearance, :controllers, :passwords],
       default: t('flashes.failure_after_update'))
   end

--- a/app/controllers/clearance/sessions_controller.rb
+++ b/app/controllers/clearance/sessions_controller.rb
@@ -24,7 +24,8 @@ class Clearance::SessionsController < Clearance::BaseController
       if status.success?
         redirect_back_or url_after_create
       else
-        flash.now.notice = status.failure_message
+        flash_error_key = Clearance.configuration.flash_error_key
+        flash.now[flash_error_key] = status.failure_message
         render template: "sessions/new", status: :unauthorized
       end
     end

--- a/lib/clearance/authorization.rb
+++ b/lib/clearance/authorization.rb
@@ -63,7 +63,7 @@ module Clearance
       store_location
 
       if flash_message
-        flash[:notice] = flash_message
+        flash[Clearance.configuration.flash_error_key] = flash_message
       end
 
       if signed_in?

--- a/lib/clearance/configuration.rb
+++ b/lib/clearance/configuration.rb
@@ -90,6 +90,11 @@ module Clearance
     # @return [ActiveRecord::Base]
     attr_accessor :user_model
 
+    # The key used for flash errors.
+    # Defaults to `:notice`. `:error` or `:danger` are suitable substitutions
+    # @return [Symbol]
+    attr_accessor :flash_error_key
+
     def initialize
       @allow_sign_up = true
       @cookie_expiration = ->(cookies) { 1.year.from_now.utc }
@@ -103,6 +108,7 @@ module Clearance
       @rotate_csrf_on_sign_in = nil
       @secure_cookie = false
       @sign_in_guards = []
+      @flash_error_key = :notice
     end
 
     def user_model

--- a/lib/clearance/testing/deny_access_matcher.rb
+++ b/lib/clearance/testing/deny_access_matcher.rb
@@ -79,7 +79,7 @@ module Clearance
         end
 
         def flash_notice
-          @controller.flash[:notice]
+          @controller.flash[Clearance.configuration.flash_error_key]
         end
 
         def flash_notice_value

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -170,4 +170,17 @@ describe Clearance::Configuration do
       expect(Clearance.configuration).not_to have_received(:warn)
     end
   end
+
+  context "when flash_error_key is set to :danger" do
+    it "returns configured value" do
+      Clearance.configure { |config| config.flash_error_key = :danger }
+      expect(Clearance.configuration.flash_error_key).to eq :danger
+    end
+  end
+
+  context "when flash_error_key is not specified" do
+    it "defaults to false" do
+      expect(Clearance.configuration.flash_error_key).to eq :notice
+    end
+  end
 end


### PR DESCRIPTION
Added a config option to override the default `:notice` key used for flash errors.

There's a fix in place on the 2.0 branch, but that branch hasn't seen any love in a while. This fix is backward compatible and allows the user to choose the key, which is useful if they're using Bootstrap and want to easily output `alert-danger`.

Fixes #602 