### PR TITLE
Small refactor that clears up the use of a getter function for @user_model

### DIFF
--- a/lib/clearance/configuration.rb
+++ b/lib/clearance/configuration.rb
@@ -88,7 +88,7 @@ module Clearance
     # The ActiveRecord class that represents users in your application.
     # Defaults to `::User`.
     # @return [ActiveRecord::Base]
-    attr_accessor :user_model
+    attr_writer :user_model
 
     def initialize
       @allow_sign_up = true


### PR DESCRIPTION
Change attr_accessor to attr_writer to reflect the fact that the reading/getter part of @user_model is dealt by with a custom function.