### PR TITLE
Add a check for the presence of generated code

### DIFF
--- a/lib/generators/clearance/install/install_generator.rb
+++ b/lib/generators/clearance/install/install_generator.rb
@@ -20,7 +20,10 @@ module Clearance
       end
 
       def create_or_inject_clearance_into_user_model
-        if File.exist? "app/models/user.rb"
+        if (File.exist? "app/models/user.rb") &&
+           (File.readlines("app/models/user.rb")
+                .grep(/include Clearance::User/)
+                .size.zero?)
           inject_into_file(
             "app/models/user.rb",
             "  include Clearance::User\n\n",

--- a/spec/support/generator_spec_helpers.rb
+++ b/spec/support/generator_spec_helpers.rb
@@ -21,6 +21,9 @@ module GeneratorSpecHelpers
     copy_to_generator_root("app/models", versionize_template("user.rb"))
     allow(File).to receive(:exist?).and_call_original
     allow(File).to receive(:exist?).with("app/models/user.rb").and_return(true)
+    allow(File).to receive(:readlines)
+      .with("app/models/user.rb")
+      .and_return(user_class_content)
   end
 
   private
@@ -39,6 +42,10 @@ module GeneratorSpecHelpers
     end
 
     template_file
+  end
+
+  def user_class_content
+    File.readlines("#{destination_root}/app/models/user.rb")
   end
 end
 


### PR DESCRIPTION
It is possible to run the generator twice and append include
Clearance::User twice. This change keeps that from happening by checking
to see if Clearance::User has already been included in the file.

I'm not sure on the best way to write a test around this because it requires
the user to run the generator twice. I would love some feedback on testing
this change. Thanks!