### PR TITLE
Guard against unsafe Clearance::BackDoor use

### DIFF
--- a/lib/clearance/back_door.rb
+++ b/lib/clearance/back_door.rb
@@ -31,6 +31,10 @@ module Clearance
   #   visit new_feedback_path(as: user)
   class BackDoor
     def initialize(app, &block)
+      unless ENV["RAILS_ENV"] == "test"
+        raise "Can't use backdoor outside test environment"
+      end
+
       @app = app
       @block = block
     end

--- a/spec/clearance/back_door_spec.rb
+++ b/spec/clearance/back_door_spec.rb
@@ -1,6 +1,9 @@
 require "spec_helper"
+require "support/environment"
 
 describe Clearance::BackDoor do
+  include EnvironmentSupport
+
   it "signs in as a given user" do
     user_id = "123"
     user = double("user")
@@ -36,6 +39,13 @@ describe Clearance::BackDoor do
 
     expect(env[:clearance]).to have_received(:sign_in).with(user)
     expect(result).to eq mock_app.call(env)
+  end
+
+  it "can't be used outside the test environment" do
+    with_environment("RAILS_ENV" => "production") do
+      expect { Clearance::BackDoor.new(mock_app) }.
+        to raise_exception "Can't use backdoor outside test environment"
+    end
   end
 
   def env_without_user_id

--- a/spec/support/environment.rb
+++ b/spec/support/environment.rb
@@ -1,0 +1,12 @@
+module EnvironmentSupport
+  def with_environment(replacement_env)
+    original_env = ENV.to_hash
+    ENV.update(replacement_env)
+
+    begin
+      yield
+    ensure
+      ENV.replace(original_env)
+    end
+  end
+end


### PR DESCRIPTION
Thanks for including the `Clearance::BackDoor` - it really speeds up tests & I've adapted it to use on other non-Clearance project too.

One modification I end up making in other places I use this backdoor is a guard against incorrect configuration. 

If one accidentally included the backdoor in `config/application.rb` rather than `config/environments/test.rb` it could lead to attacks on an application by specifying `?as=<user_id>` in production.

In general overly defensive code is a bad thing, but in this case is a little bit of paranoia worth entertaining?