### PR TITLE
Do not update bundler before travis run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ gemfile:
 
 before_install:
   - gem update --system
-  - gem update bundler
 
 install:
   - "bin/setup"


### PR DESCRIPTION
With bundler 2.0 released, this causes issues on bundle step in CI