### PR TITLE
Release version 1.16.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    clearance (1.16.1)
+    clearance (1.16.2)
       actionmailer (>= 3.1)
       activemodel (>= 3.1)
       activerecord (>= 3.1)

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@
 The noteworthy changes for each Clearance version are included here. For a
 complete changelog, see the git history for each version via the version links.
 
-## [Unreleased]
+## [1.16.2] - February 25, 2019
 
 ### Fixed
 - Added missing translation keys
@@ -16,7 +16,7 @@ complete changelog, see the git history for each version via the version links.
   frameworks relevant to Clearance.
 - Prevent `Clearance::BackDoor` from being used outside the "test" environment.
 
-[Unreleased]: https://github.com/thoughtbot/clearance/compare/v1.16.1...HEAD
+[1.16.2]: https://github.com/thoughtbot/clearance/compare/v1.16.1...v1.16.2
 
 ## [1.16.1] - November 2, 2017
 

--- a/lib/clearance/version.rb
+++ b/lib/clearance/version.rb
@@ -1,3 +1,3 @@
 module Clearance
-  VERSION = "1.16.1".freeze
+  VERSION = "1.16.2".freeze
 end


### PR DESCRIPTION
Current plan is:

- Merge this PR in, tag version at this commit, push to rubygems
- Create a `v-1-stable` branch off the release commit which will allow more 1.x releases if needed
- Merge in https://github.com/thoughtbot/clearance/pull/817 to master and push a 2.0 rc release shortly afterwards