### PR TITLE
Update copyright year in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,7 +438,7 @@ Thank you, [contributors]!
 
 ## License
 
-Clearance is copyright © 2009-2018 thoughtbot. It is free software, and may be
+Clearance is copyright © 2009-2019 thoughtbot. It is free software, and may be
 redistributed under the terms specified in the [`LICENSE`] file.
 
 [`LICENSE`]: /LICENSE


### PR DESCRIPTION
I noticed the copyright year in README.md was still set to 2018 rather than 2019 as it is currently. This pull request changes that. This change might be better included in a larger PR although I'm not sure on which issue to start with first so I fixed something simple to start off with (Maintainers: you have an intermediate level first-issue you'd recommend I tackle let me know 😄).