### PR TITLE
Fix Issue #829 (Allow Clearance::BackDoor in development environments)

### DIFF
--- a/lib/clearance/back_door.rb
+++ b/lib/clearance/back_door.rb
@@ -31,8 +31,9 @@ module Clearance
   #   visit new_feedback_path(as: user)
   class BackDoor
     def initialize(app, &block)
-      unless ENV["RAILS_ENV"] == "test"
-        raise "Can't use backdoor outside test environment"
+      @allowed_envs = Clearance.configuration.allowed_envs || ["test", "ci", "development"]
+      unless @allowed_envs.include? ENV["RAILS_ENV"]
+        raise "Can't use backdoor outside of explicitly allowed environments"
       end
 
       @app = app

--- a/lib/clearance/back_door.rb
+++ b/lib/clearance/back_door.rb
@@ -31,9 +31,14 @@ module Clearance
   #   visit new_feedback_path(as: user)
   class BackDoor
     def initialize(app, &block)
-      @allowed_envs = Clearance.configuration.allowed_envs || ["test", "ci", "development"]
+      @allowed_envs = Clearance.configuration.allowed_envs
+        || [
+              "test",
+              "ci",
+              "development"
+            ]
       unless @allowed_envs.include? ENV["RAILS_ENV"]
-        raise "Can't use backdoor outside of explicitly allowed environments"
+        raise "Can't use backdoor outside of explicitly allowed envs"
       end
 
       @app = app

--- a/lib/clearance/back_door.rb
+++ b/lib/clearance/back_door.rb
@@ -31,12 +31,7 @@ module Clearance
   #   visit new_feedback_path(as: user)
   class BackDoor
     def initialize(app, &block)
-      @allowed_envs = Clearance.configuration.allowed_envs
-        || [
-              "test",
-              "ci",
-              "development"
-            ]
+      @allowed_envs = Clearance.configuration.allowed_envs || ["test", "ci", "development"]
       unless @allowed_envs.include? ENV["RAILS_ENV"]
         raise "Can't use backdoor outside of explicitly allowed envs"
       end

--- a/lib/clearance/back_door.rb
+++ b/lib/clearance/back_door.rb
@@ -31,7 +31,7 @@ module Clearance
   #   visit new_feedback_path(as: user)
   class BackDoor
     def initialize(app, &block)
-      unless Clearance.configuration.allowed_backdoor_environments.include? ENV["RAILS_ENV"]
+      unless environment_is_allowed?
         raise "Can't use backdoor outside of explicitly allowed envs"
       end
 
@@ -64,6 +64,14 @@ module Clearance
       else
         Clearance.configuration.user_model.find(user_param)
       end
+    end
+
+    # @api private
+    def environment_is_allowed?
+      unless Clearance.configuration.allowed_backdoor_environments.include? ENV["RAILS_ENV"]
+        return false
+      end
+      return true
     end
   end
 end

--- a/lib/clearance/back_door.rb
+++ b/lib/clearance/back_door.rb
@@ -31,8 +31,7 @@ module Clearance
   #   visit new_feedback_path(as: user)
   class BackDoor
     def initialize(app, &block)
-      @allowed_envs = Clearance.configuration.allowed_envs || ["test", "ci", "development"]
-      unless @allowed_envs.include? ENV["RAILS_ENV"]
+      unless Clearance.configuration.allowed_backdoor_environments.include? ENV["RAILS_ENV"]
         raise "Can't use backdoor outside of explicitly allowed envs"
       end
 

--- a/lib/clearance/configuration.rb
+++ b/lib/clearance/configuration.rb
@@ -90,7 +90,7 @@ module Clearance
     # @return [ActiveRecord::Base]
     attr_accessor :user_model
 
-    # The array of explictly allowed environments to use the Clearance::BackDoor in.
+    # The array of explictly allowed environments to use Clearance::BackDoor in.
     # Defaults to ["test", "ci", "development"]
     # @return [Array<String>]
     attr_accessor :allowed_envs

--- a/lib/clearance/configuration.rb
+++ b/lib/clearance/configuration.rb
@@ -93,7 +93,7 @@ module Clearance
     # The array of explictly allowed environments to use Clearance::BackDoor in.
     # Defaults to ["test", "ci", "development"]
     # @return [Array<String>]
-    attr_accessor :allowed_envs
+    attr_accessor :allowed_backdoor_environments
 
     def initialize
       @allow_sign_up = true

--- a/lib/clearance/configuration.rb
+++ b/lib/clearance/configuration.rb
@@ -108,7 +108,7 @@ module Clearance
       @rotate_csrf_on_sign_in = nil
       @secure_cookie = false
       @sign_in_guards = []
-      @allowed_envs = ["test", "ci", "development"]
+      @allowed_backdoor_environments = ["test", "ci", "development"]
     end
 
     def user_model

--- a/lib/clearance/configuration.rb
+++ b/lib/clearance/configuration.rb
@@ -90,6 +90,11 @@ module Clearance
     # @return [ActiveRecord::Base]
     attr_accessor :user_model
 
+    # The array of explictly allowed environments to use the Clearance::BackDoor in.
+    # Defaults to ["test", "ci", "development"]
+    # @return [Array<String>]
+    attr_accessor :allowed_envs
+
     def initialize
       @allow_sign_up = true
       @cookie_expiration = ->(cookies) { 1.year.from_now.utc }
@@ -103,6 +108,7 @@ module Clearance
       @rotate_csrf_on_sign_in = nil
       @secure_cookie = false
       @sign_in_guards = []
+      @allowed_envs = ["test", "ci", "development"]
     end
 
     def user_model

--- a/spec/clearance/back_door_spec.rb
+++ b/spec/clearance/back_door_spec.rb
@@ -48,6 +48,22 @@ describe Clearance::BackDoor do
     end
   end
 
+  it "can be used with non-default explicitly allowed envs" do
+    Clearance.configuration.allowed_backdoor_environments.push("demo")
+    with_environment("RAILS_ENV" => "demo") do
+      user_id = "123"
+      user = double("user")
+      allow(User).to receive(:find).with(user_id).and_return(user)
+      env = env_for_user_id(user_id)
+      back_door = Clearance::BackDoor.new(mock_app)
+
+      result = back_door.call(env)
+
+      expect(env[:clearance]).to have_received(:sign_in).with(user)
+      expect(result).to eq mock_app.call(env)
+    end 
+  end
+
   def env_without_user_id
     env_for_user_id("")
   end

--- a/spec/clearance/back_door_spec.rb
+++ b/spec/clearance/back_door_spec.rb
@@ -41,10 +41,10 @@ describe Clearance::BackDoor do
     expect(result).to eq mock_app.call(env)
   end
 
-  it "can't be used outside the test environment" do
+  it "can't be used outside the explicitly allowed environments" do
     with_environment("RAILS_ENV" => "production") do
       expect { Clearance::BackDoor.new(mock_app) }.
-        to raise_exception "Can't use backdoor outside test environment"
+        to raise_exception "Can't use backdoor outside of explicitly allowed environments"
     end
   end
 

--- a/spec/clearance/back_door_spec.rb
+++ b/spec/clearance/back_door_spec.rb
@@ -41,10 +41,10 @@ describe Clearance::BackDoor do
     expect(result).to eq mock_app.call(env)
   end
 
-  it "can't be used outside the explicitly allowed environments" do
+  it "can't be used outside the explicitly allowed envs" do
     with_environment("RAILS_ENV" => "production") do
       expect { Clearance::BackDoor.new(mock_app) }.
-        to raise_exception "Can't use backdoor outside of explicitly allowed environments"
+        to raise_exception "Can't use backdoor outside of explicitly allowed envs"
     end
   end
 


### PR DESCRIPTION
This pull request merges a fix which fixes Issue #829. The developer can now specify an array of allowed environments to allow Clearance::BackDoor. I modified existing test cases to account for the changes I made (perhaps I should add more tests?).

For further context see: https://github.com/thoughtbot/clearance/issues/829