### PR TITLE
Release version 1.17.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    clearance (1.16.2)
+    clearance (1.17.0)
       actionmailer (>= 3.1)
       activemodel (>= 3.1)
       activerecord (>= 3.1)

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@
 The noteworthy changes for each Clearance version are included here. For a
 complete changelog, see the git history for each version via the version links.
 
-## [Unreleased]
+## [1.17.0] - April 11, 2019
 
 ### Changed
 
@@ -12,7 +12,7 @@ complete changelog, see the git history for each version via the version links.
 - Add configuration option to allow the auth backdoor to work in specified
   environments (defaults to `test`, `development`, `ci`).
 
-[Unreleased]: https://github.com/thoughtbot/clearance/compare/v1.16.2...HEAD
+[1.17.0]: https://github.com/thoughtbot/clearance/compare/v1.16.2...1.17.0
 
 ## [1.16.2] - February 25, 2019
 

--- a/lib/clearance/version.rb
+++ b/lib/clearance/version.rb
@@ -1,3 +1,3 @@
 module Clearance
-  VERSION = "1.16.2".freeze
+  VERSION = "1.17.0".freeze
 end


### PR DESCRIPTION
This includes the change to the `httponly` default, and the introduction of configurable envs for allowing the backdoor to work. Will push tomorrow if no objections.