### PR TITLE
WIP: Add Argon2 Password Strategy

### DIFF
--- a/clearance.gemspec
+++ b/clearance.gemspec
@@ -4,6 +4,7 @@ require 'date'
 
 Gem::Specification.new do |s|
   s.add_dependency 'bcrypt'
+  s.add_dependency 'argon2', '~> 2.0', '>= 2.0.2'
   s.add_dependency 'email_validator', '~> 1.4'
   s.add_dependency 'railties', '>= 3.1'
   s.add_dependency 'activemodel', '>= 3.1'

--- a/lib/clearance/password_strategies/argon2.rb
+++ b/lib/clearance/password_strategies/argon2.rb
@@ -1,0 +1,26 @@
+module Clearance
+    module PasswordStrategies
+      # Uses Argon2 to authenticate users and store encrypted passwords.
+
+      module Argon2
+        require 'argon2'
+  
+        def authenticated?(password)
+          if encrypted_password.present?
+            Argon2::Password.verify_password(password, encrypted_password)
+          end
+        end
+  
+        def password=(new_password)
+          @password = new_password
+  
+          if new_password.present?
+            hasher = Argon2::Password.new(t_cost: 2, m_cost: 16)
+  
+            self.encrypted_password = hasher.create("password")
+          end
+        end
+      end
+    end
+  end
+  


### PR DESCRIPTION
This pull request is a work in progress to add the Argon2 password hashing method as a built-in password strategy. At this time as I'm collecting feedback, I haven't added any rspec tests yet, additionally I will have to add the capability to configure the costs.

**MAINTAINERS:** If I need to create an issue to track this feature request and provide a place for general feedback please let me know, otherwise I'll keep in this pull request.

**Background:** The password hashing competition found Argon2 as a successor to bcrypt (https://github.com/P-H-C/phc-winner-argon2).

**Drawbacks:** This adds an additional dependency to Clearance, additionally the available platforms supporting Argon2 may be limited.

**Dependencies:** This adds https://rubygems.org/gems/argon2 (https://github.com/technion/ruby-argon2/) as a dependency.

**Other notes:** In 2016 @derekprior closed https://github.com/thoughtbot/clearance/pull/654 which accomplishes the same task I'm aiming to do. Will this be reconsidered as it's 2019 now and several things have changed in Clearance? Likewise the aforementioned PR will be a good reference for building up this PR as it's rediscussed. This may also mean if we don't want multiple password hashing dependencies that  users are migrated over to argon2 (easier said than done, we  also need to look at platform support for libargon2 which is pulled in).