### PR TITLE
Do not test against Rails 4.2 if Ruby version is 2.6.x

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -1,9 +1,14 @@
 rails_versions = %w(
-  4.2
   5.0
   5.1
   5.2
 )
+
+if RUBY_VERSION < "2.6"
+  # Rails 4.x + Ruby 2.6 raises a ThreadError and tests will break
+  # https://github.com/rails/rails/issues/34790
+  rails_versions.prepend(4.2)
+end
 
 rails_versions.each do |version|
   appraise "rails_#{version}" do


### PR DESCRIPTION
Rails 4.2 raises a ThreadError with Ruby 2.6 and higher, as documented in: https://github.com/rails/rails/issues/34790

This just a simple way to prevent tests from breaking if your current Ruby version is 2.6 or higher. I've noticed this combination is already allowed to break in Travis configuration file.