### PR TITLE
Fix intermittent example failure in token expiration spec

### DIFF
--- a/spec/requests/token_expiration_spec.rb
+++ b/spec/requests/token_expiration_spec.rb
@@ -3,8 +3,13 @@ require "spec_helper"
 describe "Token expiration" do
   describe "after signing in" do
     before do
+      Timecop.freeze
       create_user_and_sign_in
       @initial_cookies = remember_token_cookies
+    end
+
+    after do
+      Timecop.return
     end
 
     it "should have a remember_token cookie with a future expiration" do


### PR DESCRIPTION
I have seen this fail randomly when working on a different fix. Without this, the example does not account for time spent actually running the test.