### PR TITLE
Allow cookie_domain to be a string or a callable

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,16 @@ Clearance.configure do |config|
 end
 ```
 
+### Multiple Domain Support
+
+You can support multiple domains, or other special domain configurations by optionally setting `cookie_domain` as a callable object. The first argument passed to the method is an ActionDispatch::Request object.
+
+```ruby
+Clearance.configure do |config|
+  config.cookie_domain = lambda { |request| request.host }
+end
+```
+
 ### Integrating with Rack Applications
 
 Clearance adds its session to the Rack environment hash so middleware and other

--- a/lib/clearance/session.rb
+++ b/lib/clearance/session.rb
@@ -165,10 +165,12 @@ module Clearance
 
     # @api private
     def domain
-      if Clearance.configuration.cookie_domain.respond_to?(:call)
-        Clearance.configuration.cookie_domain.call(ActionDispatch::Request.new(@env))
+      configured_cookie_domain = Clearance.configuration.cookie_domain
+
+      if configured_cookie_domain.respond_to?(:call)
+        configured_cookie_domain.call(ActionDispatch::Request.new(@env))
       else
-        Clearance.configuration.cookie_domain
+        configured_cookie_domain
       end
     end
   end

--- a/lib/clearance/session.rb
+++ b/lib/clearance/session.rb
@@ -154,13 +154,22 @@ module Clearance
     # @api private
     def cookie_options
       {
-        domain: Clearance.configuration.cookie_domain,
+        domain: domain,
         expires: remember_token_expires,
         httponly: Clearance.configuration.httponly,
         path: Clearance.configuration.cookie_path,
         secure: Clearance.configuration.secure_cookie,
         value: remember_token,
       }
+    end
+
+    # @api private
+    def domain
+      if Clearance.configuration.cookie_domain.respond_to?(:call)
+        Clearance.configuration.cookie_domain.call(ActionDispatch::Request.new(@env))
+      else
+        Clearance.configuration.cookie_domain
+      end
     end
   end
 end

--- a/spec/clearance/session_spec.rb
+++ b/spec/clearance/session_spec.rb
@@ -238,27 +238,27 @@ describe Clearance::Session do
     end
   end
 
-  describe 'cookie domain option' do
-    context 'when set' do
+  describe "cookie domain option" do
+    context "when set" do
       before do
         Clearance.configuration.cookie_domain = cookie_domain
         session.sign_in(user)
       end
 
-      context 'with string' do
-        let(:cookie_domain) { '.example.com' }
+      context "with string" do
+        let(:cookie_domain) { ".example.com" }
 
-        it 'sets a standard cookie' do
+        it "sets a standard cookie" do
           session.add_cookie_to_headers(headers)
 
           expect(headers['Set-Cookie']).to match(/domain=\.example\.com; path/)
         end
       end
 
-      context 'with lambda' do
-        let(:cookie_domain) { lambda {|r| '.example.com' } }
+      context "with lambda" do
+        let(:cookie_domain) { lambda { |_r| ".example.com" } }
 
-        it 'sets a standard cookie' do
+        it "sets a standard cookie" do
           session.add_cookie_to_headers(headers)
 
           expect(headers['Set-Cookie']).to match(/domain=\.example\.com; path/)
@@ -272,7 +272,7 @@ describe Clearance::Session do
       it 'sets a standard cookie' do
         session.add_cookie_to_headers(headers)
 
-        expect(headers['Set-Cookie']).not_to match(/domain=.+; path/)
+        expect(headers["Set-Cookie"]).not_to match(/domain=.+; path/)
       end
     end
   end
@@ -284,7 +284,7 @@ describe Clearance::Session do
       it 'sets a standard cookie' do
         session.add_cookie_to_headers(headers)
 
-        expect(headers['Set-Cookie']).to_not match(/domain=.+; path/)
+        expect(headers["Set-Cookie"]).to_not match(/domain=.+; path/)
       end
     end
 

--- a/spec/clearance/session_spec.rb
+++ b/spec/clearance/session_spec.rb
@@ -241,14 +241,28 @@ describe Clearance::Session do
   describe 'cookie domain option' do
     context 'when set' do
       before do
-        Clearance.configuration.cookie_domain = '.example.com'
+        Clearance.configuration.cookie_domain = cookie_domain
         session.sign_in(user)
       end
 
-      it 'sets a standard cookie' do
-        session.add_cookie_to_headers(headers)
+      context 'with string' do
+        let(:cookie_domain) { '.example.com' }
 
-        expect(headers['Set-Cookie']).to match(/domain=\.example\.com; path/)
+        it 'sets a standard cookie' do
+          session.add_cookie_to_headers(headers)
+
+          expect(headers['Set-Cookie']).to match(/domain=\.example\.com; path/)
+        end
+      end
+
+      context 'with lambda' do
+        let(:cookie_domain) { lambda {|r| '.example.com' } }
+
+        it 'sets a standard cookie' do
+          session.add_cookie_to_headers(headers)
+
+          expect(headers['Set-Cookie']).to match(/domain=\.example\.com; path/)
+        end
       end
     end
 


### PR DESCRIPTION
This allows `Clearance.configuration.cookie_domain` to be a callable object or method to support special cookie_domain configurations

Close #786 and #563