### PR TITLE
Support configuring custom user model with a string

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Clearance.configure do |config|
   config.rotate_csrf_on_sign_in = false
   config.secure_cookie = false
   config.sign_in_guards = []
-  config.user_model = User
+  config.user_model = "User"
 end
 ```
 

--- a/lib/clearance/configuration.rb
+++ b/lib/clearance/configuration.rb
@@ -112,7 +112,7 @@ module Clearance
     end
 
     def user_model
-      @user_model ||= ::User
+      (@user_model || "User").to_s.constantize
     end
 
     # Is the user sign up route enabled?

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -8,9 +8,22 @@ describe Clearance::Configuration do
   end
 
   context "when a custom user_model_name is specified" do
-    it "is used instead of User" do
+    before(:each) do
       MyUser = Class.new
+    end
+
+    after(:each) do
+      Object.send(:remove_const, :MyUser)
+    end
+
+    it "is used instead of User" do
       Clearance.configure { |config| config.user_model = MyUser }
+
+      expect(Clearance.configuration.user_model).to eq ::MyUser
+    end
+
+    it "can be specified as a string to avoid triggering autoloading" do
+      Clearance.configure { |config| config.user_model = "MyUser" }
 
       expect(Clearance.configuration.user_model).to eq ::MyUser
     end


### PR DESCRIPTION
Resolves https://github.com/thoughtbot/clearance/issues/842

Since Rails 6.0 has switched to the Zeitwerk autoloader, referencing a model in an intializer triggers a deprecation warning:

```
Initialization autoloaded the constants ApplicationRecord and MyCustomUser
```

I've given this patch a try in a Rails 6.0 application which was displaying the deprecation warning and it resolved the issue.