### PR TITLE
Support for the `SameSite` cookie attribute

### DIFF
--- a/lib/clearance/configuration.rb
+++ b/lib/clearance/configuration.rb
@@ -42,6 +42,15 @@ module Clearance
     # @return [Boolean]
     attr_accessor :httponly
 
+    # Same-site cookies ("First-Party-Only" or "First-Party") allow servers to
+    # mitigate the risk of CSRF and information leakage attacks by asserting
+    # that a particular cookie should only be sent with requests initiated from
+    # the same registrable domain.
+    # Defaults to `nil`. For more, see
+    # [RFC6265](https://tools.ietf.org/html/draft-west-first-party-cookies-06#section-4.1.1).
+    # @return [String]
+    attr_accessor :same_site
+
     # Controls the address the password reset email is sent from.
     # Defaults to reply@example.com.
     # @return [String]
@@ -103,6 +112,7 @@ module Clearance
       @cookie_name = "remember_token"
       @cookie_path = '/'
       @httponly = true
+      @same_site = nil
       @mailer_sender = 'reply@example.com'
       @redirect_url = '/'
       @rotate_csrf_on_sign_in = nil

--- a/lib/clearance/session.rb
+++ b/lib/clearance/session.rb
@@ -157,6 +157,7 @@ module Clearance
         domain: Clearance.configuration.cookie_domain,
         expires: remember_token_expires,
         httponly: Clearance.configuration.httponly,
+        same_site: Clearance.configuration.same_site,
         path: Clearance.configuration.cookie_path,
         secure: Clearance.configuration.secure_cookie,
         value: remember_token,

--- a/spec/clearance/session_spec.rb
+++ b/spec/clearance/session_spec.rb
@@ -170,6 +170,31 @@ describe Clearance::Session do
     end
   end
 
+  context "if same_site is set" do
+    before do
+      Clearance.configuration.same_site = :lax
+      session.sign_in(user)
+    end
+
+    it "sets a same-site cookie" do
+      session.add_cookie_to_headers(headers)
+
+      expect(headers["Set-Cookie"]).to match(/remember_token=.+; SameSite/)
+    end
+  end
+
+  context "if same_site is not set" do
+    before do
+      session.sign_in(user)
+    end
+
+    it "sets a standard cookie" do
+      session.add_cookie_to_headers(headers)
+
+      expect(headers["Set-Cookie"]).to_not match(/remember_token=.+; SameSite/)
+    end
+  end
+
   describe 'remember token cookie expiration' do
     context 'default configuration' do
       it 'is set to 1 year from now' do


### PR DESCRIPTION
Same-site cookies is another layer to help prevent CSRF attacks. The feature is in [draft yet](https://tools.ietf.org/html/draft-west-first-party-cookies-06#section-4.1.1), but is already supported by modern browsers https://caniuse.com/#feat=same-site-cookie-attribute