### PR TITLE
Allow BCrypt cost value to be configured

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       actionmailer (>= 5.0)
       activemodel (>= 5.0)
       activerecord (>= 5.0)
-      bcrypt
+      bcrypt (>= 3.1.1)
       email_validator (~> 1.4)
       railties (>= 5.0)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,11 @@
 The noteworthy changes for each Clearance version are included here. For a
 complete changelog, see the git history for each version via the version links.
 
-## Unreleased
+## [Unreleased]
+
+### Added
+
+- Add ability to configure BCrypt computational cost of hash calculation.
 
 ### Fixed
 

--- a/clearance.gemspec
+++ b/clearance.gemspec
@@ -2,7 +2,7 @@ $LOAD_PATH.push File.expand_path('../lib', __FILE__)
 require 'clearance/version'
 
 Gem::Specification.new do |s|
-  s.add_dependency 'bcrypt'
+  s.add_dependency 'bcrypt', '>= 3.1.1'
   s.add_dependency 'email_validator', '~> 1.4'
   s.add_dependency 'railties', '>= 5.0'
   s.add_dependency 'activemodel', '>= 5.0'

--- a/lib/clearance/password_strategies/bcrypt.rb
+++ b/lib/clearance/password_strategies/bcrypt.rb
@@ -2,10 +2,14 @@ module Clearance
   module PasswordStrategies
     # Uses BCrypt to authenticate users and store encrypted passwords.
     #
-    # The BCrypt cost (the measure of how many key expansion iterations BCrypt
-    # will perform) is automatically set to the minimum allowed value when
-    # Rails is operating in the test environment and the default cost in all
-    # other envionments. This provides a speed boost in tests.
+    # BCrypt has a `cost` argument which determines how computationally
+    # expensive the hash is to calculate. The higher the cost, the harder it is
+    # for attackers to crack passwords even if they posess a database dump of
+    # the encrypted passwords. Clearance uses the `bcrypt-ruby` default cost
+    # except in the test environment, where it uses the minimum cost value for
+    # speed. If you wish to increase the cost over the default, you can do so
+    # by setting a higher cost in an initializer:
+    # `BCrypt::Engine.cost = 12`
     module BCrypt
       require 'bcrypt'
 
@@ -19,16 +23,18 @@ module Clearance
         @password = new_password
 
         if new_password.present?
-          cost = if defined?(::Rails) && ::Rails.env.test?
-                   ::BCrypt::Engine::MIN_COST
-                 else
-                   ::BCrypt::Engine::DEFAULT_COST
-                 end
-
           self.encrypted_password = ::BCrypt::Password.create(
             new_password,
-            cost: cost,
+            cost: configured_bcrypt_cost,
           )
+        end
+      end
+
+      def configured_bcrypt_cost
+        if defined?(::Rails) && ::Rails.env.test?
+          ::BCrypt::Engine::MIN_COST
+        else
+          ::BCrypt::Engine.cost
         end
       end
     end

--- a/spec/password_strategies/bcrypt_spec.rb
+++ b/spec/password_strategies/bcrypt_spec.rb
@@ -22,8 +22,21 @@ describe Clearance::PasswordStrategies::BCrypt do
 
       expect(BCrypt::Password).to have_received(:create).with(
         password,
-        cost: ::BCrypt::Engine::DEFAULT_COST
+        cost: ::BCrypt::Engine::DEFAULT_COST,
       )
+    end
+
+    it "uses an explicity configured BCrypt cost" do
+      stub_bcrypt_cost(8)
+      bcrypt_password = BCrypt::Password.create(password, cost: nil)
+
+      expect(bcrypt_password.cost).to eq(8)
+    end
+
+    it "uses the default BCrypt cost value implicitly" do
+      bcrypt_password = BCrypt::Password.create(password, cost: nil)
+
+      expect(bcrypt_password.cost).to eq(BCrypt::Engine::DEFAULT_COST)
     end
 
     it "encrypts with BCrypt using minimum cost in test environment" do
@@ -40,6 +53,10 @@ describe Clearance::PasswordStrategies::BCrypt do
 
     def stub_bcrypt_password
       allow(BCrypt::Password).to receive(:create).and_return(encrypted_password)
+    end
+
+    def stub_bcrypt_cost(cost)
+      allow(BCrypt::Engine).to receive(:cost).and_return(cost)
     end
 
     def encrypted_password


### PR DESCRIPTION
This is a rebase and slight clean-up of https://github.com/thoughtbot/clearance/pull/787