### PR TITLE
Fix broken `deny_access` rspec matcher

### DIFF
--- a/lib/clearance/testing/deny_access_matcher.rb
+++ b/lib/clearance/testing/deny_access_matcher.rb
@@ -78,12 +78,8 @@ module Clearance
           @controller.request.env[:clearance]
         end
 
-        def flash_alert
-          @controller.flash[:alert]
-        end
-
         def flash_alert_value
-          flash_alert.values.first
+          @controller.flash[:alert]
         end
 
         def redirects_to_url?

--- a/spec/clearance/testing/deny_access_matcher_spec.rb
+++ b/spec/clearance/testing/deny_access_matcher_spec.rb
@@ -1,0 +1,32 @@
+require "spec_helper"
+
+class PretendFriendsController < ActionController::Base
+  include Clearance::Controller
+  before_action :require_login
+
+  def index
+  end
+end
+
+describe PretendFriendsController, type: :controller do
+  before do
+    Rails.application.routes.draw do
+      resources :pretend_friends, only: :index
+      get "/sign_in"  => "clearance/sessions#new", as: "sign_in"
+    end
+  end
+
+  after do
+    Rails.application.reload_routes!
+  end
+
+  it "checks contents of deny access flash" do
+    get :index
+
+    expect(subject).to deny_access(flash: failure_message)
+  end
+
+  def failure_message
+    I18n.t("flashes.failure_when_not_signed_in")
+  end
+end


### PR DESCRIPTION
In a previous commit deprecating old rails behavior, we mistakenly deprecated
the newer behavior instead of the older behavior.

This change fixes our deprecation mistake, and adds some basic flexing of this
matcher in the existing spec suite to ensure that we're at least running it with
a flash check involved.

Resolves https://github.com/thoughtbot/clearance/issues/858