### PR TITLE
Allow sign in guards to be specified as strings

### DIFF
--- a/lib/clearance/session.rb
+++ b/lib/clearance/session.rb
@@ -147,7 +147,7 @@ module Clearance
       guards = Clearance.configuration.sign_in_guards
 
       guards.inject(default_guard) do |stack, guard_class|
-        guard_class.new(self, stack)
+        guard_class.to_s.constantize.new(self, stack)
       end
     end
 

--- a/spec/clearance/session_spec.rb
+++ b/spec/clearance/session_spec.rb
@@ -129,6 +129,12 @@ describe Clearance::Session do
 
       def stub_guard_class(guard)
         double("guard_class").tap do |guard_class|
+          allow(guard_class).to receive(:to_s).
+            and_return(guard_class)
+
+          allow(guard_class).to receive(:constantize).
+            and_return(guard_class)
+
           allow(guard_class).to receive(:new).
             with(session, stub_default_sign_in_guard).
             and_return(guard)


### PR DESCRIPTION
Since Rails 6.0 has switched to the Zeitwerk autoloader, referencing
a model in an intializer triggers a deprecation warning:

"Initialization autoloaded the constants ApplicationRecord and MyCustomUser"

See this issue for further details:
https://github.com/thoughtbot/clearance/issues/842