### PR TITLE
Update README for Rails and Ruby version requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ monitored by contributors.
 
 ## Getting Started
 
-Clearance is a Rails engine tested against Rails `>= 3.2` and Ruby `>= 1.9.3`.
+Clearance is a Rails engine tested against Rails `>= 5.0` and Ruby `>= 2.4.0`.
 
 You can add it to your Gemfile with:
 


### PR DESCRIPTION
Based on clearance.gemspec and .travis.yml, Clearance is tested against Rails 5.0 and later and Ruby >= 2.4.0. This change updates the README to reflect that.

It might be better to say `>= 2.4` instead of `>= 2.4.0` in the README. Let me know if I should use that instead.
