### PR TITLE
Update email_validator gem and relax validations

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ PATH
       activemodel (>= 5.0)
       activerecord (>= 5.0)
       bcrypt (>= 3.1.1)
-      email_validator (~> 1.4)
+      email_validator (~> 2.0)
       railties (>= 5.0)
 
 GEM
@@ -70,7 +70,7 @@ GEM
     crass (1.0.5)
     database_cleaner (1.7.0)
     diff-lcs (1.3)
-    email_validator (1.6.0)
+    email_validator (2.0.1)
       activemodel
     erubi (1.9.0)
     factory_bot (5.1.1)

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,10 @@ complete changelog, see the git history for each version via the version links.
 
 - Delete cookies when custom domain is being used.
 
+### Changed
+
+- Update `email_validator` gem and use more relaxed email validation options.
+
 [Unreleased]: https://github.com/thoughtbot/clearance/compare/v2.0.0...HEAD
 
 ## [2.0.0] - November 12, 2019

--- a/clearance.gemspec
+++ b/clearance.gemspec
@@ -3,7 +3,7 @@ require 'clearance/version'
 
 Gem::Specification.new do |s|
   s.add_dependency 'bcrypt', '>= 3.1.1'
-  s.add_dependency 'email_validator', '~> 1.4'
+  s.add_dependency 'email_validator', '~> 2.0'
   s.add_dependency 'railties', '>= 5.0'
   s.add_dependency 'activemodel', '>= 5.0'
   s.add_dependency 'activerecord', '>= 5.0'

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -5,15 +5,15 @@ describe User do
   it { is_expected.to have_db_index(:remember_token) }
   it { is_expected.to validate_presence_of(:email) }
   it { is_expected.to validate_presence_of(:password) }
+  it { is_expected.to allow_value("foo;@example.com").for(:email) }
+  it { is_expected.to allow_value("foo@.example.com").for(:email) }
+  it { is_expected.to allow_value("foo@example..com").for(:email) }
   it { is_expected.to allow_value("foo@example.co.uk").for(:email) }
   it { is_expected.to allow_value("foo@example.com").for(:email) }
   it { is_expected.to allow_value("foo+bar@example.com").for(:email) }
-  it { is_expected.not_to allow_value("foo@").for(:email) }
-  it { is_expected.not_to allow_value("foo@example..com").for(:email) }
-  it { is_expected.not_to allow_value("foo@.example.com").for(:email) }
-  it { is_expected.not_to allow_value("foo").for(:email) }
   it { is_expected.not_to allow_value("example.com").for(:email) }
-  it { is_expected.not_to allow_value("foo;@example.com").for(:email) }
+  it { is_expected.not_to allow_value("foo").for(:email) }
+  it { is_expected.not_to allow_value("foo@").for(:email) }
 
   describe "#email" do
     it "stores email in down case and removes whitespace" do


### PR DESCRIPTION
The gem we use for email format validation recently changed its approach to
validation and radically relaxed the gem validation.

This blog post was part of the rationale: https://medium.com/hackernoon/the-100-correct-way-to-validate-email-addresses-7c4818f24643

This change updates the version of the gem we are using, and as a side effect,
relaxes the requirements for valid email addresses by default in clearance user
models.

Resolves https://github.com/thoughtbot/clearance/issues/839