### PR TITLE
Clean up sql output in generated migration

### DIFF
--- a/lib/generators/clearance/install/templates/db/migrate/add_clearance_to_users.rb.erb
+++ b/lib/generators/clearance/install/templates/db/migrate/add_clearance_to_users.rb.erb
@@ -13,7 +13,7 @@ class AddClearanceToUsers < ActiveRecord::Migration<%= migration_version %>
     users = select_all("SELECT id FROM users WHERE remember_token IS NULL")
 
     users.each do |user|
-      update <<-SQL
+      update <<-SQL.squish
         UPDATE users
         SET remember_token = '#{Clearance::Token.new}'
         WHERE id = '#{user['id']}'


### PR DESCRIPTION
Adding the `squish` here has the effect of slightly cleaning up the eventual SQL
generated by the migration we are helping create here. Before this change the
migration would be full of newlines (or `\n`). Post-change, each sql statement
should come out cleaner in the logs with the line breaks and tabs/spaces
replaced by just one space each.

The SQL that is run stays the same, it just looks slightly nicer in the log
output.