### PR TITLE
Add parent_controller configuration option

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,11 @@ complete changelog, see the git history for each version via the version links.
 
 ## Unreleased
 
+### Added
+
+- Add `parent_controller` configuration option to specify the controller that
+  `BaseController` will inherit from. Defaults to `ApplicationController`.
+
 ### Fixed
 
 - Delete cookies when custom domain is being used.

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Clearance.configure do |config|
   config.secure_cookie = false
   config.sign_in_guards = []
   config.user_model = "User"
+  config.parent_controller = "ApplicationController"
 end
 ```
 

--- a/app/controllers/clearance/base_controller.rb
+++ b/app/controllers/clearance/base_controller.rb
@@ -1,2 +1,9 @@
-class Clearance::BaseController < ApplicationController
+module Clearance
+  # Top-level base class that all Clearance controllers inherit from.
+  # Inherits from `ApplicationController` by default and can be overridden by
+  # setting a new value with {Configuration#parent_controller=}.
+  # @!parse
+  #   class BaseController < ApplicationController; end
+  class BaseController < Clearance.configuration.parent_controller
+  end
 end

--- a/lib/clearance/configuration.rb
+++ b/lib/clearance/configuration.rb
@@ -100,6 +100,11 @@ module Clearance
     # @return [ActiveRecord::Base]
     attr_writer :user_model
 
+    # The controller class that all Clearance controllers will inherit from.
+    # Defaults to `::ApplicationController`.
+    # @return [ActionController::Base]
+    attr_writer :parent_controller
+
     # The array of allowed environments where `Clearance::BackDoor` is enabled.
     # Defaults to ["test", "ci", "development"]
     # @return [Array<String>]
@@ -127,6 +132,13 @@ module Clearance
     # @return [Class]
     def user_model
       (@user_model || "User").to_s.constantize
+    end
+
+    # The class representing the configured base controller.
+    # In the default configuration, this is the `ApplicationController` class.
+    # @return [Class]
+    def parent_controller
+      (@parent_controller || "ApplicationController").to_s.constantize
     end
 
     # Is the user sign up route enabled?

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -1,6 +1,8 @@
 require "spec_helper"
 
 describe Clearance::Configuration do
+  let(:config) { Clearance.configuration }
+
   context "when no user_model_name is specified" do
     it "defaults to User" do
       expect(Clearance.configuration.user_model).to eq ::User
@@ -26,6 +28,28 @@ describe Clearance::Configuration do
       Clearance.configure { |config| config.user_model = "MyUser" }
 
       expect(Clearance.configuration.user_model).to eq ::MyUser
+    end
+  end
+
+  context "when no parent_controller is specified" do
+    it "defaults to ApplicationController" do
+      expect(config.parent_controller).to eq ::ApplicationController
+    end
+  end
+
+  context "when a custom parent_controller is specified" do
+    before(:each) do
+      MyController = Class.new
+    end
+
+    after(:each) do
+      Object.send(:remove_const, :MyController)
+    end
+
+    it "is used instead of ApplicationController" do
+      Clearance.configure { |config| config.parent_controller = MyController }
+
+      expect(config.parent_controller).to eq ::MyController
     end
   end
 


### PR DESCRIPTION
This uses https://github.com/thoughtbot/clearance/pull/784 as a starting point and then also:

- Does a rebase against changes in master since then;
- Makes small changes to avoid some deprecation warnings that would not be generated at the time the original PR was opened, around class names vs strings of class names