### PR TITLE
Remove deprecation warning around rotate csrf default

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -26,6 +26,8 @@ complete changelog, see the git history for each version via the version links.
 ### Removed
 
 - Remove unused route to `passwords#create` nested under `users`.
+- Remove the deprecation notice around the `rotate_csrf_on_sign_in` setting, and
+  make it default to true.
 
 [Unreleased]: https://github.com/thoughtbot/clearance/compare/v2.0.0...HEAD
 

--- a/README.md
+++ b/README.md
@@ -59,17 +59,13 @@ Clearance.configure do |config|
   config.mailer_sender = "reply@example.com"
   config.password_strategy = Clearance::PasswordStrategies::BCrypt
   config.redirect_url = "/"
-  config.rotate_csrf_on_sign_in = false
+  config.rotate_csrf_on_sign_in = true
   config.secure_cookie = false
   config.sign_in_guards = []
   config.user_model = "User"
   config.parent_controller = "ApplicationController"
 end
 ```
-
-The install generator will set `rotate_csrf_on_sign_in` to `true`, so new
-installations will get this behavior from the start. This helps avoid session
-fixation attacks, and will become the default in Clearance 2.0.
 
 ## Use
 

--- a/lib/clearance/configuration.rb
+++ b/lib/clearance/configuration.rb
@@ -121,7 +121,7 @@ module Clearance
       @same_site = nil
       @mailer_sender = 'reply@example.com'
       @redirect_url = '/'
-      @rotate_csrf_on_sign_in = nil
+      @rotate_csrf_on_sign_in = true
       @routes = true
       @secure_cookie = false
       @sign_in_guards = []
@@ -193,22 +193,7 @@ module Clearance
     end
 
     def rotate_csrf_on_sign_in?
-      if rotate_csrf_on_sign_in.nil?
-        warn <<-EOM.squish
-          Clearance's `rotate_csrf_on_sign_in` configuration setting is unset and
-          will be treated as `false`. Setting this value to `true` is
-          recommended to avoid session fixation attacks and will be the default
-          in Clearance 2.0. It is recommended that you opt-in to this setting
-          now and test your application. To silence this warning, set
-          `rotate_csrf_on_sign_in` to `true` or `false` in Clearance's
-          initializer.
-
-          For more information on session fixation, see:
-            https://www.owasp.org/index.php/Session_fixation
-        EOM
-      end
-
-      rotate_csrf_on_sign_in
+      !!rotate_csrf_on_sign_in
     end
   end
 

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -183,28 +183,22 @@ describe Clearance::Configuration do
   end
 
   describe "#rotate_csrf_on_sign_in?" do
-    it "defaults to falsey and warns" do
-      Clearance.configuration = Clearance::Configuration.new
-      allow(Clearance.configuration).to receive(:warn)
-
-      expect(Clearance.configuration.rotate_csrf_on_sign_in?).to be_falsey
-      expect(Clearance.configuration).to have_received(:warn)
-    end
-
-    it "is true and does not warn when `rotate_csrf_on_sign_in` is true" do
+    it "is true when `rotate_csrf_on_sign_in` is set to true" do
       Clearance.configure { |config| config.rotate_csrf_on_sign_in = true }
-      allow(Clearance.configuration).to receive(:warn)
 
       expect(Clearance.configuration.rotate_csrf_on_sign_in?).to be true
-      expect(Clearance.configuration).not_to have_received(:warn)
     end
 
-    it "is false and does not warn when `rotate_csrf_on_sign_in` is false" do
+    it "is false when `rotate_csrf_on_sign_in` is set to false" do
       Clearance.configure { |config| config.rotate_csrf_on_sign_in = false }
-      allow(Clearance.configuration).to receive(:warn)
 
       expect(Clearance.configuration.rotate_csrf_on_sign_in?).to be false
-      expect(Clearance.configuration).not_to have_received(:warn)
+    end
+
+    it "is false when `rotate_csrf_on_sign_in` is set to nil" do
+      Clearance.configure { |config| config.rotate_csrf_on_sign_in = nil }
+
+      expect(Clearance.configuration.rotate_csrf_on_sign_in?).to be false
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -46,5 +46,4 @@ end
 
 def restore_default_warning_free_config
   Clearance.configuration = nil
-  Clearance.configure { |config| config.rotate_csrf_on_sign_in = true }
 end


### PR DESCRIPTION
This change was previously scheduled to roll out in 2.0, but was missed. This
change removes the deprecation warning message, and makes the change that the
warning message claimed was coming (default this config option to true).