### PR TITLE
Support a configured primary_key_type while generating migration

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,8 @@ complete changelog, see the git history for each version via the version links.
 
 - Add `parent_controller` configuration option to specify the controller that
   `BaseController` will inherit from. Defaults to `ApplicationController`.
+- Use a configured `primary_key_type` (for example: `:uuid`) if one is set while
+  generating the migration for the users table.
 
 ### Fixed
 

--- a/lib/generators/clearance/install/install_generator.rb
+++ b/lib/generators/clearance/install/install_generator.rb
@@ -122,6 +122,16 @@ module Clearance
         "[#{Rails::VERSION::MAJOR}.#{Rails::VERSION::MINOR}]"
       end
 
+      def migration_primary_key_type_string
+        if configured_key_type
+          ", id: :#{configured_key_type}"
+        end
+      end
+
+      def configured_key_type
+        Rails.configuration.generators.active_record[:primary_key_type]
+      end
+
       def models_inherit_from
         "ApplicationRecord"
       end

--- a/lib/generators/clearance/install/templates/db/migrate/create_users.rb.erb
+++ b/lib/generators/clearance/install/templates/db/migrate/create_users.rb.erb
@@ -1,6 +1,6 @@
 class CreateUsers < ActiveRecord::Migration<%= migration_version %>
   def change
-    create_table :users do |t|
+    create_table :users<%= migration_primary_key_type_string %> do |t|
       t.timestamps null: false
       t.string :email, null: false
       t.string :encrypted_password, limit: 128, null: false


### PR DESCRIPTION
This change makes it so that if the containing Rails application clearance is
being used in has set the database primary_key_type to an alternate setting (ie,
uuid instead of integer id), the migration clearance generates and inserts into
the application will include that type setting.

Resolves https://github.com/thoughtbot/clearance/issues/809