### PR TITLE
Add a flash alert for missing email on password reset

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,10 @@ complete changelog, see the git history for each version via the version links.
 ### Changed
 
 - Update `email_validator` gem and use more relaxed email validation options.
+- When a password reset request is submitted without an email address, a flash
+  alert is now provided. Previously this continued silently as though it had
+  worked. We still proceed that way when there is an invalid (but present)
+  value, so as not to reveal existent vs. non-existent emails.
 
 ### Removed
 

--- a/app/controllers/clearance/passwords_controller.rb
+++ b/app/controllers/clearance/passwords_controller.rb
@@ -2,6 +2,7 @@ require 'active_support/deprecation'
 
 class Clearance::PasswordsController < Clearance::BaseController
   before_action :ensure_existing_user, only: [:edit, :update]
+  before_action :ensure_email_present, only: [:create]
   skip_before_action :require_login, only: [:create, :edit, :new, :update], raise: false
 
   def new
@@ -77,6 +78,13 @@ class Clearance::PasswordsController < Clearance::BaseController
     find_user_by_id_and_confirmation_token
   end
 
+  def ensure_email_present
+    if email_from_password_params.blank?
+      flash_failure_when_missing_email
+      render template: "passwords/new"
+    end
+  end
+
   def ensure_existing_user
     unless find_user_by_id_and_confirmation_token
       flash_failure_when_forbidden
@@ -94,6 +102,12 @@ class Clearance::PasswordsController < Clearance::BaseController
     flash.now[:alert] = translate(:blank_password,
       scope: [:clearance, :controllers, :passwords],
       default: t("flashes.failure_after_update"))
+  end
+
+  def flash_failure_when_missing_email
+    flash.now[:alert] = translate(:missing_email,
+      scope: [:clearance, :controllers, :passwords],
+      default: t("flashes.failure_when_missing_email"))
   end
 
   def url_after_update

--- a/config/locales/clearance.en.yml
+++ b/config/locales/clearance.en.yml
@@ -17,6 +17,7 @@ en:
     failure_when_forbidden: Please double check the URL or try submitting
       the form again.
     failure_when_not_signed_in: Please sign in to continue.
+    failure_when_missing_email: Email can't be blank.
   helpers:
     label:
       password:

--- a/spec/controllers/passwords_controller_spec.rb
+++ b/spec/controllers/passwords_controller_spec.rb
@@ -38,12 +38,26 @@ describe Clearance::PasswordsController do
     end
 
     context "email param is missing" do
-      it "does not raise error" do
-        expect do
-          post :create, params: {
-            password: {},
+      it "displays flash error on new page" do
+        post :create, params: {
+          password: {},
+        }
+
+        expect(flash.now[:alert]).to match(/email can't be blank/i)
+        expect(response).to render_template(:new)
+      end
+    end
+
+    context "email param is blank" do
+      it "displays flash error on new page" do
+        post :create, params: {
+          password: {
+            email: "",
           }
-        end.not_to raise_error
+        }
+
+        expect(flash.now[:alert]).to match(/email can't be blank/i)
+        expect(response).to render_template(:new)
       end
     end
 


### PR DESCRIPTION
Previously a user could submit a password reset request with an empty form (no
email address) and clearance would proceed as though everything was fine and
we'd done a reset and would be emailing them.

This change adds an error to the flash when there is no value provided at all.

Importantly, the behavior between "present but invalid email" and "present but
valid email" remains the same; since we don't want to tip off the presence or
absence of a specific value in the database.

Resolves https://github.com/thoughtbot/clearance/issues/601