### PR TITLE
Remove rails-version specific test setup for user model

### DIFF
--- a/spec/app_templates/app/models/rails5/user.rb
+++ b/spec/app_templates/app/models/rails5/user.rb
@@ -1,5 +1,0 @@
-class User < ApplicationRecord
-  def previously_existed?
-    true
-  end
-end

--- a/spec/app_templates/app/models/user.rb
+++ b/spec/app_templates/app/models/user.rb
@@ -1,4 +1,4 @@
-class User < ActiveRecord::Base
+class User < ApplicationRecord
   def previously_existed?
     true
   end

--- a/spec/support/generator_spec_helpers.rb
+++ b/spec/support/generator_spec_helpers.rb
@@ -18,7 +18,7 @@ module GeneratorSpecHelpers
   end
 
   def provide_existing_user_class
-    copy_to_generator_root("app/models", versionize_template("user.rb"))
+    copy_to_generator_root("app/models", "user.rb")
     allow(File).to receive(:exist?).and_call_original
     allow(File).to receive(:exist?).with("app/models/user.rb").and_return(true)
   end
@@ -31,10 +31,6 @@ module GeneratorSpecHelpers
 
     FileUtils.mkdir_p(destination)
     FileUtils.cp(template_file, destination)
-  end
-
-  def versionize_template(template_file)
-    ["rails5", template_file].join("/")
   end
 end
 


### PR DESCRIPTION
We no longer support rails versions prior to 5.0, so don't need this custom
check.