### PR TITLE
Travis: Drop unused sudo: false directive

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,5 +28,3 @@ matrix:
   exclude:
     - rvm: 2.4.6
       gemfile: gemfiles/rails_6.0.gemfile
-
-sudo: false


### PR DESCRIPTION
This PR removes the no-longer-used Travis setting `sudo: false`. See [more at the Travis blog](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).