### PR TITLE
Remove gem update step from travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,6 @@ gemfile:
   - gemfiles/rails_5.2.gemfile
   - gemfiles/rails_6.0.gemfile
 
-before_install:
-  - gem update --system
-
 install:
   - "bin/setup"
 


### PR DESCRIPTION
This step was causing failures related to the rubygems install on travis having
conflicts with an already existing `bundle` binary (from the rvm ruby install).