### PR TITLE
Deliver password reset email inline

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,24 +285,6 @@ and `password` attributes. Over-riding the `email_optional?` or
 `skip_password_validation?` methods to return `true` will disable those
 validations from being added.
 
-### Deliver Email in Background Job
-
-Clearance has a password reset mailer. If you are using Rails 4.2 and Clearance
-1.6 or greater, Clearance will use ActiveJob's `deliver_later` method to
-automatically take advantage of your configured queue.
-
-If you are using an earlier version of Rails, you can override the
-`Clearance::Passwords` controller and define the behavior you need in the
-`deliver_email` method.
-
-```ruby
-class PasswordsController < Clearance::PasswordsController
-  def deliver_email(user)
-    ClearanceMailer.delay.change_password(user)
-  end
-end
-```
-
 ## Extending Sign In
 
 By default, Clearance will sign in any user with valid credentials. If you need

--- a/app/controllers/clearance/passwords_controller.rb
+++ b/app/controllers/clearance/passwords_controller.rb
@@ -45,8 +45,7 @@ class Clearance::PasswordsController < Clearance::BaseController
   private
 
   def deliver_email(user)
-    mail = ::ClearanceMailer.change_password(user)
-    mail.deliver_later
+    ::ClearanceMailer.change_password(user).deliver_now
   end
 
   def password_from_password_reset_params


### PR DESCRIPTION
This commit changes the delivery behavior of the password reset email.
Before, it queued the email for later delivery.
Now, it delivers the email immediately.

The queue can be backed up, have no running workers, or other issues.
These issues can cause delay or no email delivery,
leading the user to abandon the site or contact support.
In the case of no delivery, there is also no error trace.

Inlining delivery also lets the programmer handle error cases such as
the email delivery service experiencing downtime or degraded service
or the email delivery service responding that it can't deliver the email
(such as a badly formatted or non-existent email address).
Handling these errors can help the user fix their own typos, etc.

Lastly, a project that integrates Clearance no longer needs to have
an ActiveJob-compatible background job process in their project.

https://api.rubyonrails.org/classes/ActionMailer/MessageDelivery.html#method-i-deliver_now