### PR TITLE
Fix unsafe ERB interpolation & add ERB lint

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -1,0 +1,5 @@
+---
+EnableDefaultLinters: true
+linters:
+  ErbSafety:
+    enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'ammeter'
 gem 'appraisal'
 gem 'capybara'
 gem 'database_cleaner'
-gem "erb_lint", require: false
+gem 'erb_lint', require: false
 gem 'factory_bot_rails'
 gem 'nokogiri'
 gem 'pry', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem 'ammeter'
 gem 'appraisal'
 gem 'capybara'
 gem 'database_cleaner'
+gem "erb_lint", require: false
 gem 'factory_bot_rails'
 gem 'nokogiri'
 gem 'pry', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,7 +59,16 @@ GEM
     argon2 (2.0.2)
       ffi (~> 1.9)
       ffi-compiler (>= 0.1)
+    ast (2.4.1)
     bcrypt (3.1.15)
+    better_html (1.0.15)
+      actionview (>= 4.0)
+      activesupport (>= 4.0)
+      ast (~> 2.0)
+      erubi (~> 1.4)
+      html_tokenizer (~> 0.0.6)
+      parser (>= 2.4)
+      smart_properties
     builder (3.2.4)
     capybara (3.33.0)
       addressable
@@ -76,6 +85,13 @@ GEM
     diff-lcs (1.4.4)
     email_validator (2.0.1)
       activemodel
+    erb_lint (0.0.34)
+      activesupport
+      better_html (~> 1.0.7)
+      html_tokenizer
+      rainbow
+      rubocop (~> 0.79)
+      smart_properties
     erubi (1.9.0)
     factory_bot (6.1.0)
       activesupport (>= 5.0.0)
@@ -88,6 +104,7 @@ GEM
       rake
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    html_tokenizer (0.0.7)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
     loofah (2.6.0)
@@ -101,6 +118,9 @@ GEM
     minitest (5.14.1)
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
+    parallel (1.19.2)
+    parser (2.7.1.4)
+      ast (~> 2.4.1)
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -123,8 +143,10 @@ GEM
       method_source
       rake (>= 0.8.7)
       thor (>= 0.20.3, < 2.0)
+    rainbow (3.0.0)
     rake (13.0.1)
     regexp_parser (1.7.1)
+    rexml (3.2.4)
     rspec-core (3.9.2)
       rspec-support (~> 3.9.3)
     rspec-expectations (3.9.2)
@@ -142,14 +164,28 @@ GEM
       rspec-mocks (~> 3.9)
       rspec-support (~> 3.9)
     rspec-support (3.9.3)
+    rubocop (0.88.0)
+      parallel (~> 1.10)
+      parser (>= 2.7.1.1)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.7)
+      rexml
+      rubocop-ast (>= 0.1.0, < 1.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 2.0)
+    rubocop-ast (0.3.0)
+      parser (>= 2.7.1.4)
+    ruby-progressbar (1.10.1)
     shoulda-matchers (4.3.0)
       activesupport (>= 4.2.0)
+    smart_properties (1.15.0)
     sqlite3 (1.4.2)
     thor (1.0.1)
     thread_safe (0.3.6)
     timecop (0.9.1)
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
+    unicode-display_width (1.7.0)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.4.0)
@@ -164,6 +200,7 @@ DEPENDENCIES
   capybara
   clearance!
   database_cleaner
+  erb_lint
   factory_bot_rails
   nokogiri
   pry

--- a/Rakefile
+++ b/Rakefile
@@ -22,5 +22,10 @@ RSpec::Core::RakeTask.new("spec:acceptance") do |task|
   task.verbose = false
 end
 
+desc "Lint ERB templates"
+task :erb_lint do
+  sh("bundle", "exec", "erblint", "app/views/**/*.erb")
+end
+
 desc "Run the specs and acceptance tests"
 task default: %w(spec spec:acceptance)

--- a/Rakefile
+++ b/Rakefile
@@ -28,4 +28,4 @@ task :erb_lint do
 end
 
 desc "Run the specs and acceptance tests"
-task default: %w(spec spec:acceptance)
+task default: %w(spec spec:acceptance erb_lint)

--- a/app/views/clearance_mailer/change_password.html.erb
+++ b/app/views/clearance_mailer/change_password.html.erb
@@ -2,7 +2,7 @@
 
 <p>
   <%= link_to t(".link_text", default: "Change my password"),
-    edit_user_password_url(@user, token: @user.confirmation_token.html_safe) %>
+    edit_user_password_url(@user, token: @user.confirmation_token) %>
 </p>
 
-<p><%= raw t(".closing") %></p>
+<p><%= t(".closing") %></p>

--- a/app/views/clearance_mailer/change_password.text.erb
+++ b/app/views/clearance_mailer/change_password.text.erb
@@ -1,5 +1,5 @@
 <%= t(".opening") %>
 
-<%= edit_user_password_url(@user, token: @user.confirmation_token.html_safe) %>
+<%= edit_user_password_url(@user, token: @user.confirmation_token) %>
 
-<%= raw t(".closing") %>
+<%= t(".closing") %>

--- a/gemfiles/rails_5.0.gemfile
+++ b/gemfiles/rails_5.0.gemfile
@@ -7,6 +7,7 @@ gem "ammeter"
 gem "appraisal"
 gem "capybara", ">= 2.6.2", "< 3.33.0"
 gem "database_cleaner"
+gem "erb_lint", require: false
 gem "factory_bot_rails"
 gem "nokogiri"
 gem "pry", require: false

--- a/gemfiles/rails_5.1.gemfile
+++ b/gemfiles/rails_5.1.gemfile
@@ -7,6 +7,7 @@ gem "ammeter"
 gem "appraisal"
 gem "capybara"
 gem "database_cleaner"
+gem "erb_lint", require: false
 gem "factory_bot_rails"
 gem "nokogiri"
 gem "pry", require: false

--- a/gemfiles/rails_5.2.gemfile
+++ b/gemfiles/rails_5.2.gemfile
@@ -7,6 +7,7 @@ gem "ammeter"
 gem "appraisal"
 gem "capybara"
 gem "database_cleaner"
+gem "erb_lint", require: false
 gem "factory_bot_rails"
 gem "nokogiri"
 gem "pry", require: false

--- a/gemfiles/rails_6.0.gemfile
+++ b/gemfiles/rails_6.0.gemfile
@@ -7,6 +7,7 @@ gem "ammeter"
 gem "appraisal"
 gem "capybara"
 gem "database_cleaner"
+gem "erb_lint", require: false
 gem "factory_bot_rails"
 gem "nokogiri"
 gem "pry", require: false


### PR DESCRIPTION
A Rails application I'm working on uses [ERB lint](https://github.com/Shopify/erb-lint) which flags a couple of issues in views generated by Clearance.

I've fixed these issues in the templates locally but would like to upstream the fixes to save other Clearance + ERB lint users the same issues.

## Changes

- Fixes 'unsafe interpolation' warnings
  - These don't appear to be actual a XSS security risks, because it's not user-generated content, but they're still unnecessary uses of `raw` / `html_safe` in views
- Adds `erb_lint` Rake task
- Adds `erb_lint` task to the default Rake task