### PR TITLE
Explicitly specify email uniqueness validator as case insensitive

### DIFF
--- a/lib/clearance/user.rb
+++ b/lib/clearance/user.rb
@@ -143,7 +143,7 @@ module Clearance
         validates :email,
           email: { strict_mode: true },
           presence: true,
-          uniqueness: { allow_blank: true },
+          uniqueness: { allow_blank: true, case_sensitive: false },
           unless: :email_optional?
 
         validates :password, presence: true, unless: :skip_password_validation?


### PR DESCRIPTION
Fixes deprecation warning from Rails 6.0.x versions:

> DEPRECATION WARNING: Uniqueness validator will no longer enforce case
sensitive comparison in Rails 6.1. To continue case sensitive comparison
on the :email attribute in User model, pass `case_sensitive: true`
option explicitly to the uniqueness validator.

Since the `case_sensitive` option has been supported on Rails since 1.x, this should be completely safe, while also being explicit enough for Rails 6+ to not throw any deprecation warnings.