### PR TITLE
Sign in guards should be specified as strings since Rails 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ Here's an example custom guard to handle email confirmation:
 
 ```ruby
 Clearance.configure do |config|
-  config.sign_in_guards = [EmailConfirmationGuard]
+  config.sign_in_guards = ["EmailConfirmationGuard"]
 end
 ```
 


### PR DESCRIPTION
While running system tests, I received 
`DEPRECATION WARNING: Initialization autoloaded the constants...`

According to https://github.com/thoughtbot/clearance/issues/842 and https://github.com/thoughtbot/clearance/pull/862 guards should be now specified as strings.