### PR TITLE
Remove unused locale keys.

### DIFF
--- a/config/locales/clearance.en.yml
+++ b/config/locales/clearance.en.yml
@@ -1,9 +1,5 @@
 ---
 en:
-  clearance:
-    models:
-      clearance_mailer:
-        change_password: Change your password
   clearance_mailer:
     change_password:
       closing: If you didn't request this, ignore this email. Your password has


### PR DESCRIPTION
It seems it's not used anywhere?
Looking for example at https://github.com/thoughtbot/clearance-i18n/blob/master/config/locales/de.yml confirms that, I guess?