### PR TITLE
Tiny changes to make clearance Neo4j-compatible

### DIFF
--- a/app/controllers/clearance/passwords_controller.rb
+++ b/app/controllers/clearance/passwords_controller.rb
@@ -58,7 +58,7 @@ class Clearance::PasswordsController < Clearance::BaseController
     token = params[:token] || session[:password_reset_token]
 
     Clearance.configuration.user_model.
-      find_by_id_and_confirmation_token params[user_param], token.to_s
+      find_by(id: params[user_param], confirmation_token: token.to_s)
   end
 
   def email_from_password_params

--- a/lib/clearance/user.rb
+++ b/lib/clearance/user.rb
@@ -121,7 +121,7 @@ module Clearance
       end
 
       def find_by_normalized_email(email)
-        find_by_email normalize_email(email)
+        find_by(email: normalize_email(email))
       end
 
       def normalize_email(email)


### PR DESCRIPTION
I began this journey curious if Clearance would tolerate a Rails app backed by ActiveGraph instead of ActiveRecord. A quick grep of the Clearance codebase suggested it just might be possible... there is very little (if any) hard coupling to ActiveRecord.

These two tiny changes do not break ActiveRecord compatibility and don't alter the semantics of the queries they're performing.

`ActiveGraph` (previously `Neo4j.rb`) largely conforms to ActiveRecord interfaces but one of the things it lacks is the dynamically-defined `find_by_*` methods. However, it does contain `find_by(property:)` methods and changing these two lines makes Clearance work perfectly on a Neo4j.rb codebase.

I would love it if this change is acceptable to the thoughtbot folks so I can return to consuming the official gem. Please let me know if you have any questions. Thanks!