### PR TITLE
Add parameter stripping to BackDoor

### DIFF
--- a/lib/clearance/back_door.rb
+++ b/lib/clearance/back_door.rb
@@ -49,7 +49,8 @@ module Clearance
     # @api private
     def sign_in_through_the_back_door(env)
       params = Rack::Utils.parse_query(env["QUERY_STRING"])
-      user_param = params["as"]
+      user_param = params.delete("as")
+      env["QUERY_STRING"] = Rack::Utils.build_query(params)
 
       if user_param.present?
         user = find_user(user_param)

--- a/spec/clearance/back_door_spec.rb
+++ b/spec/clearance/back_door_spec.rb
@@ -46,6 +46,18 @@ describe Clearance::BackDoor do
     end
   end
 
+  it "strips 'as' from the params" do
+    user_id = "123"
+    user = double("user")
+    allow(User).to receive(:find).with(user_id).and_return(user)
+    env = env_for_user_id(user_id)
+    back_door = Clearance::BackDoor.new(mock_app)
+
+    back_door.call(env)
+
+    expect(env["QUERY_STRING"]).to be_empty
+  end
+
   context "when the environments are disabled" do
     before do
       Clearance.configuration.allowed_backdoor_environments = nil


### PR DESCRIPTION
Before, we were leaving the "as" parameter in the query string when accessing the back door. Doing so was causing problems downstream when the consuming application was using [Strong Parameters]. If the app had not listed the "as" parameter as a permitted parameter, then tests would fail. We added functionality to the back door to strip out the "as" parameter before calling the next middleware.

[Strong Parameters]: https://api.rubyonrails.org/classes/ActionController/StrongParameters.html