### PR TITLE
Delete remember cookie when domain is a Proc

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,11 @@
 The noteworthy changes for each Clearance version are included here. For a
 complete changelog, see the git history for each version via the version links.
 
+### Fixed
+
+- Delete cookie correctly when a callable object is set as the custom domain
+  setting.
+
 ## [2.2.0] - July 9, 2020
 
 ### Added

--- a/lib/clearance/session.rb
+++ b/lib/clearance/session.rb
@@ -175,7 +175,7 @@ module Clearance
     def delete_cookie_options
       Hash.new.tap do |options|
         if configured_cookie_domain
-          options[:domain] = configured_cookie_domain
+          options[:domain] = domain
         end
       end
     end

--- a/spec/clearance/session_spec.rb
+++ b/spec/clearance/session_spec.rb
@@ -378,6 +378,25 @@ describe Clearance::Session do
         expect(cookie_jar.deleted?(:remember_token, domain: domain)).to be true
       end
     end
+
+    context 'with callable cookie domain' do
+      it 'clears cookie' do
+        domain = '.example.com'
+        Clearance.configuration.cookie_domain = ->(_) { domain }
+        user = create(:user)
+        env = env_with_remember_token(
+          value: user.remember_token,
+          domain: domain
+        )
+        session = Clearance::Session.new(env)
+        cookie_jar = ActionDispatch::Request.new(env).cookie_jar
+        expect(cookie_jar.deleted?(:remember_token, domain: domain)).to be false
+
+        session.sign_out
+
+        expect(cookie_jar.deleted?(:remember_token, domain: domain)).to be true
+      end
+    end
   end
 
   def env_with_cookies(cookies)


### PR DESCRIPTION
The `cookie_domain` setting [can be set to a callable][1] to allow
support for multiple domains.

When we generated the [options used to delete the cookie][2] we passed
the setting value directly. When the setting was a callable this passed
the callable rather than the value.

This commit resolves the domain and uses the value in the options.

[1]: https://github.com/thoughtbot/clearance/blob/c3da4f62a7300b177d3b7d02b246144f6d473372/README.md#multiple-domain-support
[2]: https://api.rubyonrails.org/classes/ActionDispatch/Cookies.html