### PR TITLE
Bump all dev dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,16 +2,16 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'addressable', '~> 2.6.0'
+gem 'addressable'
 gem 'ammeter'
 gem 'appraisal'
 gem 'capybara'
-gem 'database_cleaner', '~> 1.0'
-gem 'factory_bot_rails', '~> 5.0'
-gem 'nokogiri', '~> 1.10.0'
+gem 'database_cleaner'
+gem 'factory_bot_rails'
+gem 'nokogiri'
 gem 'pry', require: false
 gem 'rails-controller-testing'
-gem 'rspec-rails', '~> 4.0.0.beta3'
-gem 'shoulda-matchers', '~> 4.1'
+gem 'rspec-rails'
+gem 'shoulda-matchers'
 gem 'sqlite3'
-gem 'timecop', '~> 0.6'
+gem 'timecop'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,8 +46,8 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
       zeitwerk (~> 2.2, >= 2.2.2)
-    addressable (2.6.0)
-      public_suffix (>= 2.0.2, < 4.0)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
     ammeter (1.1.4)
       activesupport (>= 3.0)
       railties (>= 3.0)
@@ -59,9 +59,9 @@ GEM
     argon2 (2.0.2)
       ffi (~> 1.9)
       ffi-compiler (>= 0.1)
-    bcrypt (3.1.13)
+    bcrypt (3.1.15)
     builder (3.2.4)
-    capybara (3.21.0)
+    capybara (3.33.0)
       addressable
       mini_mime (>= 0.1.3)
       nokogiri (~> 1.8)
@@ -77,18 +77,18 @@ GEM
     email_validator (2.0.1)
       activemodel
     erubi (1.9.0)
-    factory_bot (5.2.0)
-      activesupport (>= 4.2.0)
-    factory_bot_rails (5.2.0)
-      factory_bot (~> 5.2.0)
-      railties (>= 4.2.0)
+    factory_bot (6.1.0)
+      activesupport (>= 5.0.0)
+    factory_bot_rails (6.1.0)
+      factory_bot (~> 6.1.0)
+      railties (>= 5.0.0)
     ffi (1.13.1)
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
       rake
     globalid (0.4.2)
       activesupport (>= 4.2.0)
-    i18n (1.8.3)
+    i18n (1.8.5)
       concurrent-ruby (~> 1.0)
     loofah (2.6.0)
       crass (~> 1.0.2)
@@ -104,7 +104,7 @@ GEM
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    public_suffix (3.1.1)
+    public_suffix (4.0.5)
     rack (2.2.3)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
@@ -152,26 +152,26 @@ GEM
       thread_safe (~> 0.1)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.3.1)
+    zeitwerk (2.4.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  addressable (~> 2.6.0)
+  addressable
   ammeter
   appraisal
   capybara
   clearance!
-  database_cleaner (~> 1.0)
-  factory_bot_rails (~> 5.0)
-  nokogiri (~> 1.10.0)
+  database_cleaner
+  factory_bot_rails
+  nokogiri
   pry
   rails-controller-testing
-  rspec-rails (~> 4.0.0.beta3)
-  shoulda-matchers (~> 4.1)
+  rspec-rails
+  shoulda-matchers
   sqlite3
-  timecop (~> 0.6)
+  timecop
 
 BUNDLED WITH
    2.1.4

--- a/gemfiles/rails_5.0.gemfile
+++ b/gemfiles/rails_5.0.gemfile
@@ -2,19 +2,19 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.6.0"
+gem "addressable"
 gem "ammeter"
 gem "appraisal"
 gem "capybara", ">= 2.6.2", "< 3.33.0"
-gem "database_cleaner", "~> 1.0"
-gem "factory_bot_rails", "~> 5.0"
-gem "nokogiri", "~> 1.10.0"
+gem "database_cleaner"
+gem "factory_bot_rails"
+gem "nokogiri"
 gem "pry", require: false
 gem "rails-controller-testing"
 gem "rspec-rails", "~> 3.1"
-gem "shoulda-matchers", "~> 4.1"
+gem "shoulda-matchers"
 gem "sqlite3", "~> 1.3.13"
-gem "timecop", "~> 0.6"
+gem "timecop"
 gem "railties", "~> 5.0"
 
 gemspec path: "../"

--- a/gemfiles/rails_5.1.gemfile
+++ b/gemfiles/rails_5.1.gemfile
@@ -2,19 +2,19 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.6.0"
+gem "addressable"
 gem "ammeter"
 gem "appraisal"
 gem "capybara"
-gem "database_cleaner", "~> 1.0"
-gem "factory_bot_rails", "~> 5.0"
-gem "nokogiri", "~> 1.10.0"
+gem "database_cleaner"
+gem "factory_bot_rails"
+gem "nokogiri"
 gem "pry", require: false
 gem "rails-controller-testing"
-gem "rspec-rails", "~> 3.1"
-gem "shoulda-matchers", "~> 4.1"
+gem "rspec-rails"
+gem "shoulda-matchers"
 gem "sqlite3"
-gem "timecop", "~> 0.6"
+gem "timecop"
 gem "railties", "~> 5.1"
 
 gemspec path: "../"

--- a/gemfiles/rails_5.2.gemfile
+++ b/gemfiles/rails_5.2.gemfile
@@ -2,19 +2,19 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.6.0"
+gem "addressable"
 gem "ammeter"
 gem "appraisal"
 gem "capybara"
-gem "database_cleaner", "~> 1.0"
-gem "factory_bot_rails", "~> 5.0"
-gem "nokogiri", "~> 1.10.0"
+gem "database_cleaner"
+gem "factory_bot_rails"
+gem "nokogiri"
 gem "pry", require: false
 gem "rails-controller-testing"
-gem "rspec-rails", "~> 4.0.0.beta3"
-gem "shoulda-matchers", "~> 4.1"
+gem "rspec-rails"
+gem "shoulda-matchers"
 gem "sqlite3"
-gem "timecop", "~> 0.6"
+gem "timecop"
 gem "railties", "~> 5.2"
 
 gemspec path: "../"

--- a/gemfiles/rails_6.0.gemfile
+++ b/gemfiles/rails_6.0.gemfile
@@ -2,19 +2,19 @@
 
 source "https://rubygems.org"
 
-gem "addressable", "~> 2.6.0"
+gem "addressable"
 gem "ammeter"
 gem "appraisal"
 gem "capybara"
-gem "database_cleaner", "~> 1.0"
-gem "factory_bot_rails", "~> 5.0"
-gem "nokogiri", "~> 1.10.0"
+gem "database_cleaner"
+gem "factory_bot_rails"
+gem "nokogiri"
 gem "pry", require: false
 gem "rails-controller-testing"
-gem "rspec-rails", "~> 4.0.0.beta3"
-gem "shoulda-matchers", "~> 4.1"
+gem "rspec-rails"
+gem "shoulda-matchers"
 gem "sqlite3"
-gem "timecop", "~> 0.6"
+gem "timecop"
 gem "railties", "~> 6.0"
 
 gemspec path: "../"


### PR DESCRIPTION
This commit removes the version constraints for our development
dependencies and bumps them all in both the top-level Gemfile and the
appraisal Gemfiles (via `appraisal update`).

This has the nice effect of getting rid of lots of Ruby 2.7 keyword
argument warnings in our tests. The Ruby 2.7 + Rails 6 tests is now
nothing but green dots.