### PR TITLE
Prevent user enumeration by timing attacks

### DIFF
--- a/lib/clearance/user.rb
+++ b/lib/clearance/user.rb
@@ -117,6 +117,8 @@ module Clearance
           if password.present? && user.authenticated?(password)
             user
           end
+        else
+          prevent_timing_attack
         end
       end
 
@@ -129,6 +131,13 @@ module Clearance
       end
 
       private
+
+      DUMMY_PASSWORD = "*"
+
+      def prevent_timing_attack
+        new(password: DUMMY_PASSWORD)
+        nil
+      end
 
       def password_strategy
         Clearance.configuration.password_strategy || PasswordStrategies::BCrypt

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -47,6 +47,35 @@ describe User do
       expect(User.authenticate(user.email, "bad_password")).to be_nil
     end
 
+    it "takes the same amount of time to authenticate regardless of whether user exists" do
+      user = create(:user)
+      password = user.password
+
+      user_exists_time = Benchmark.realtime do
+        User.authenticate(user.email, password)
+      end
+
+      user_does_not_exist_time = Benchmark.realtime do
+        User.authenticate("bad_email@example.com", password)
+      end
+
+      expect(user_does_not_exist_time). to be_within(0.001).of(user_exists_time)
+    end
+
+    it "takes the same amount of time to fail authentication regardless of whether user exists" do
+      user = create(:user)
+
+      user_exists_time = Benchmark.realtime do
+        User.authenticate(user.email, "bad_password")
+      end
+
+      user_does_not_exist_time = Benchmark.realtime do
+        User.authenticate("bad_email@example.com", "bad_password")
+      end
+
+      expect(user_does_not_exist_time). to be_within(0.001).of(user_exists_time)
+    end
+
     it "is retrieved via a case-insensitive search" do
       user = create(:user)
 


### PR DESCRIPTION
Closes #636

Before this commit, we were skipping any BCrypt (or other password
strategy) checks when we couldn't find the user by email. This opened up
the possibility for a bad actor to detect whether an account existed for
a given email address based on the timing of the response.

This commit mitigates the problem by creating a throw away user and
setting a dummy password on it, triggering BCrypt to create an encrypted
password.

The added tests were consistently failing before this change because
authentication for accounts that did NOT exists was taking 1-2ms longer
that for accounts that did exist (with the cost set to
::BCrypt::Engine::MIN_COST in tests). The timings are now very close.
The `be_within` delta could almost have been 0.0001, but I stuck with
1ms to avoid any flakiness in the test suite.