### PR TITLE
Fix password reset URLs when using a custom model

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@ complete changelog, see the git history for each version via the version links.
 ### Fixed
 
 - Support for accessing Rails 6.x primary_key_type in generator.
+- Fix password reset URLs when using a custom model
 
 ## [2.3.0] - August 14, 2020
 

--- a/app/views/clearance_mailer/change_password.html.erb
+++ b/app/views/clearance_mailer/change_password.html.erb
@@ -2,7 +2,7 @@
 
 <p>
   <%= link_to t(".link_text", default: "Change my password"),
-    edit_user_password_url(@user, token: @user.confirmation_token) %>
+    url_for([@user, :password, action: :edit, token: @user.confirmation_token]) %>
 </p>
 
 <p><%= t(".closing") %></p>

--- a/app/views/clearance_mailer/change_password.text.erb
+++ b/app/views/clearance_mailer/change_password.text.erb
@@ -1,5 +1,5 @@
 <%= t(".opening") %>
 
-<%= edit_user_password_url(@user, token: @user.confirmation_token) %>
+<%= url_for([@user, :password, action: :edit, token: @user.confirmation_token]) %>
 
 <%= t(".closing") %>

--- a/app/views/passwords/edit.html.erb
+++ b/app/views/passwords/edit.html.erb
@@ -4,7 +4,7 @@
   <p><%= t(".description") %></p>
 
   <%= form_for :password_reset,
-        url: user_password_path(@user, token: @user.confirmation_token),
+        url: [@user, :password, token: @user.confirmation_token],
         html: { method: :put } do |form| %>
     <div class="password-field">
       <%= form.label :password %>

--- a/spec/mailers/clearance_mailer_spec.rb
+++ b/spec/mailers/clearance_mailer_spec.rb
@@ -55,4 +55,37 @@ describe ClearanceMailer do
       text: I18n.t("clearance_mailer.change_password.link_text")
     )
   end
+
+  context "when using a custom model" do
+    it "contains a link for a custom model" do
+      define_people_routes
+      Person = Class.new(User)
+      person = Person.new(email: "person@example.com", password: "password")
+
+      person.forgot_password!
+      host = ActionMailer::Base.default_url_options[:host]
+      link = "http://#{host}/people/#{person.id}/password/edit" \
+        "?token=#{person.confirmation_token}"
+
+      email = ClearanceMailer.change_password(person)
+
+      expect(email.text_part.body).to include(link)
+      expect(email.html_part.body).to include(link)
+
+      Object.send(:remove_const, :Person)
+      Rails.application.reload_routes!
+    end
+
+    def define_people_routes
+      Rails.application.routes.draw do
+        resources :people, controller: "clearance/users", only: :create do
+          resource(
+            :password,
+            controller: "clearance/passwords",
+            only: %i[edit update],
+          )
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
When using a custom `user_model` other than `User`, generating the
password reset link and attempting to reset the password would raise an
error. This is because the URL helpers were hardcoded to use the `User`
model, such as `edit_user_password_url`.

This commit uses Rails' [PolymorphicRoutes] to build the URL from the
passed in model. This will use the record's model to generate the URL,
allowing the URL to respect any custom model.

Fixes #918

[PolymorphicRoutes]: https://api.rubyonrails.org/classes/ActionDispatch/Routing/PolymorphicRoutes.html