### PR TITLE
Revert case sensitivity for email uniqueness

### DIFF
--- a/lib/clearance/user.rb
+++ b/lib/clearance/user.rb
@@ -152,7 +152,7 @@ module Clearance
         validates :email,
           email: { strict_mode: true },
           presence: true,
-          uniqueness: { allow_blank: true, case_sensitive: false },
+          uniqueness: { allow_blank: true, case_sensitive: true },
           unless: :email_optional?
 
         validates :password, presence: true, unless: :skip_password_validation?


### PR DESCRIPTION
Hi everyone and thanks for maintaining the gem ❤️ 

Unfortunately, we ran into an issue after we updated Clearance to the latest version: some of our requests started failing due to statement timeouts in the database.

After a closer inspection it turned out the problem was related to queries on the `users` table which were changed to query by `LOWER(email)` instead of `email`. Since we didn't have the index on `LOWER(email)`, the queries for some users got significantly slower.

This is related to the change made in #889—`case_sensitive` setting of the `uniqueness` validator was set
to `false` to prevent deprecation warnings from Rails.

However, the setting should have been set to `true` to preserve backwards-compatibility.

The deprecation warning said:

> To **continue** case sensitive comparison
> on the :email attribute in User model, pass case_sensitive: true
> option explicitly to the uniqueness validator.

The problem was mentioned in an old commit that originally made the switch from the explicit `false` to the implicit `true`:
https://github.com/thoughtbot/clearance/commit/56f0f0489a138d64794136e133c5848183c576d5

If I might recommend pushing this change in a bugfix release and if `case_sensitive: false` is indeed desired, push that change in Clearance 3.0.