### PR TITLE
Fix AddClearanceToUsers down method (remove_index)

### DIFF
--- a/lib/generators/clearance/install/templates/db/migrate/add_clearance_to_users.rb.erb
+++ b/lib/generators/clearance/install/templates/db/migrate/add_clearance_to_users.rb.erb
@@ -27,5 +27,9 @@ class AddClearanceToUsers < ActiveRecord::Migration<%= migration_version %>
       t.remove <%= new_columns.keys.map { |column| ":#{column}" }.join(", ") %>
 <% end -%>
     end
+                          
+<% config[:new_indexes].values.each do |index| -%>
+    <%= index.gsub("add_index", "remove_index") %>
+<% end -%>
   end
 end

--- a/lib/generators/clearance/install/templates/db/migrate/add_clearance_to_users.rb.erb
+++ b/lib/generators/clearance/install/templates/db/migrate/add_clearance_to_users.rb.erb
@@ -21,15 +21,15 @@ class AddClearanceToUsers < ActiveRecord::Migration<%= migration_version %>
     end
   end
 
-  def self.down
+  def self.down                     
+<% config[:new_indexes].values.each do |index| -%>
+    <%= index.gsub("add_index", "remove_index") %>
+<% end -%>
+           
     change_table :users do |t|
 <% if config[:new_columns].any? -%>
       t.remove <%= new_columns.keys.map { |column| ":#{column}" }.join(", ") %>
 <% end -%>
     end
-                          
-<% config[:new_indexes].values.each do |index| -%>
-    <%= index.gsub("add_index", "remove_index") %>
-<% end -%>
   end
 end


### PR DESCRIPTION
Currently, the `self.down` method of the `AddClearanceToUsers` migration only removes the columns, but not the indexes.

So if you migrate and then rollback, you can no longer migrate:

```
rails db:migrate 
== 20210212135500 AddClearanceToUsers: migrating ==============================
-- change_table(:users)
   -> 0.0212s
-- add_index(:users, :email)
rails aborted!
StandardError: An error has occurred, this and all later migrations canceled:

PG::DuplicateTable: ERROR:  relation "index_users_on_email" already exists
/home/hans/projects/dummy/db/migrate/20210212135500_add_clearance_to_users.rb:9:in `up'
/home/hans/projects/dummy/bin/rails:9:in `<top (required)>'
/home/hans/projects/dummy/bin/spring:15:in `<top (required)>'

Caused by:
ActiveRecord::StatementInvalid: PG::DuplicateTable: ERROR:  relation "index_users_on_email" already exists
/home/hans/projects/dummy/db/migrate/20210212135500_add_clearance_to_users.rb:9:in `up'
/home/hans/projects/dummy/bin/rails:9:in `<top (required)>'
/home/hans/projects/dummy/bin/spring:15:in `<top (required)>'

Caused by:
PG::DuplicateTable: ERROR:  relation "index_users_on_email" already exists
/home/hans/projects/dummy/db/migrate/20210212135500_add_clearance_to_users.rb:9:in `up'
/home/hans/projects/dummy/bin/rails:9:in `<top (required)>'
/home/hans/projects/dummy/bin/spring:15:in `<top (required)>'
Tasks: TOP => db:migrate
(See full trace by running task with --trace)
```

This fix adds the `remove_index` calls to the `self.down` method.