### PR TITLE
Increase time range for authentication spec

### DIFF
--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -59,7 +59,7 @@ describe User do
         User.authenticate("bad_email@example.com", password)
       end
 
-      expect(user_does_not_exist_time). to be_within(0.001).of(user_exists_time)
+      expect(user_does_not_exist_time). to be_within(0.01).of(user_exists_time)
     end
 
     it "takes the same amount of time to fail authentication regardless of whether user exists" do
@@ -73,7 +73,7 @@ describe User do
         User.authenticate("bad_email@example.com", "bad_password")
       end
 
-      expect(user_does_not_exist_time). to be_within(0.001).of(user_exists_time)
+      expect(user_does_not_exist_time). to be_within(0.01).of(user_exists_time)
     end
 
     it "is retrieved via a case-insensitive search" do


### PR DESCRIPTION
In commit ce17d2d6d861bb3415602c388bbf5bda8b5fceec some specs were added
to verify that the time it takes to authenticate users that already
exist and those that don't is within 0.001s. This causes the tests to
fail randomly given that the time range is too precise. We are
increasing this range to 0.01 to avoid flaky tests.