### PR TITLE
Update status codes on failures

### DIFF
--- a/app/controllers/clearance/passwords_controller.rb
+++ b/app/controllers/clearance/passwords_controller.rb
@@ -25,7 +25,7 @@ class Clearance::PasswordsController < Clearance::BaseController
       session[:password_reset_token] = params[:token]
       redirect_to url_for
     else
-      render template: "passwords/edit"
+      render template: "passwords/edit", status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/clearance/passwords_controller.rb
+++ b/app/controllers/clearance/passwords_controller.rb
@@ -25,7 +25,7 @@ class Clearance::PasswordsController < Clearance::BaseController
       session[:password_reset_token] = params[:token]
       redirect_to url_for
     else
-      render template: "passwords/edit", status: :unprocessable_entity
+      render template: "passwords/edit"
     end
   end
 
@@ -38,7 +38,7 @@ class Clearance::PasswordsController < Clearance::BaseController
       session[:password_reset_token] = nil
     else
       flash_failure_after_update
-      render template: "passwords/edit"
+      render template: "passwords/edit", status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/clearance/users_controller.rb
+++ b/app/controllers/clearance/users_controller.rb
@@ -14,7 +14,7 @@ class Clearance::UsersController < Clearance::BaseController
       sign_in @user
       redirect_back_or url_after_create
     else
-      render template: "users/new"
+      render template: "users/new", status: :unprocessable_entity
     end
   end
 

--- a/spec/controllers/passwords_controller_spec.rb
+++ b/spec/controllers/passwords_controller_spec.rb
@@ -111,7 +111,7 @@ describe Clearance::PasswordsController do
           user_id: user,
         }
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to be_successful
         expect(response).to render_template(:edit)
         expect(assigns(:user)).to eq user
       end
@@ -211,6 +211,7 @@ describe Clearance::PasswordsController do
         )
 
         expect(flash.now[:alert]).to match(/password can't be blank/i)
+        expect(response).to have_http_status(:unprocessable_entity)
         expect(response).to render_template(:edit)
         expect(cookies[:remember_token]).to be_nil
       end

--- a/spec/controllers/passwords_controller_spec.rb
+++ b/spec/controllers/passwords_controller_spec.rb
@@ -111,7 +111,7 @@ describe Clearance::PasswordsController do
           user_id: user,
         }
 
-        expect(response).to be_successful
+        expect(response).to have_http_status(:unprocessable_entity)
         expect(response).to render_template(:edit)
         expect(assigns(:user)).to eq user
       end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -67,6 +67,20 @@ describe Clearance::UsersController do
           expect(response).to redirect_to(return_url)
         end
       end
+
+      context "with invalid attributes" do
+        it "renders the page with error" do
+          user_attributes = FactoryBot.attributes_for(:user, email: nil)
+          old_user_count = User.count
+
+          post :create, params: {
+            user: user_attributes,
+          }
+
+          expect(User.count).to eq old_user_count
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+      end
     end
 
     context "when signed in" do


### PR DESCRIPTION
This fixes one of the two issues that prevent Clearance from being compatible with Turbo. 

Simply - it updates the status for failed forms from 200 to 422. For context, Turbo will only render a 4xx/5xx response to a form. With the 200 response Turbo will do nothing, and the user will be left sitting on the form page.

I expect this would be a breaking change so should likely be slated for the next major release, along with the second fix for Turbo which is a little more involved.

Related: #929