### PR TITLE
Update REXML version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -149,7 +149,7 @@ GEM
     rainbow (3.0.0)
     rake (13.0.3)
     regexp_parser (1.7.1)
-    rexml (3.2.4)
+    rexml (3.2.5)
     rspec-core (3.9.2)
       rspec-support (~> 3.9.3)
     rspec-expectations (3.9.2)


### PR DESCRIPTION
Updating REXML version to resolved a security vulnerability found by
dependabot which it could not resolve on its own. The message from
dependabot indicated:

The REXML gem before 3.2.5 in Ruby before 2.6.7, 2.7.x before 2.7.3,
and 3.x before 3.0.1 does not properly address XML round-trip issues.
An incorrect document can be produced after parsing and serializing.