### PR TITLE
Update readme with correct httponly default

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Clearance.configure do |config|
   config.cookie_name = "remember_token"
   config.cookie_path = "/"
   config.routes = true
-  config.httponly = false
+  config.httponly = true
   config.mailer_sender = "reply@example.com"
   config.password_strategy = Clearance::PasswordStrategies::BCrypt
   config.redirect_url = "/"


### PR DESCRIPTION
In commit 4810c0c6571951dc585de7453c61c94f526af18a the default value for
httponly was changed to true, but this change was never reflected in the
default configuration mentioned in the readme.

This changed updates the readme the match the actual default value.

Fixes the issue reported in #941 .