### PR TITLE
Use `#dig` to get session data

### DIFF
--- a/lib/clearance/authentication.rb
+++ b/lib/clearance/authentication.rb
@@ -25,7 +25,7 @@ module Clearance
     # @return [User, nil] The user or nil if authentication fails.
     def authenticate(params)
       Clearance.configuration.user_model.authenticate(
-        params[:session][:email], params[:session][:password]
+        params.dig(:session, :email), params.dig(:session, :password)
       )
     end
 

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -94,6 +94,15 @@ describe Clearance::SessionsController do
         should redirect_to(return_url)
       end
     end
+
+    context "with missing credentials" do
+      it "render the page with error" do
+        post :create
+
+        expect(response).to render_template(:new)
+        expect(flash[:alert]).to match(/^Bad email or password/)
+      end
+    end
   end
 
   describe "on DELETE to #destroy" do


### PR DESCRIPTION
If the sign in form was submitted without any params (e.g. by a bot or malformed request), the `#authenticate` method would raise the 'NoMethodError: undefined method `[]' for nil:NilClass' exception.

We can work around that with `ActionController::Params#dig` which would treat missing or misnamed params just like invalid credentials.