### PR TITLE
Fix open redirect vulnerability

### DIFF
--- a/lib/clearance/authorization.rb
+++ b/lib/clearance/authorization.rb
@@ -86,8 +86,14 @@ module Clearance
     def return_to
       if return_to_url
         uri = URI.parse(return_to_url)
-        "#{uri.path}?#{uri.query}".chomp("?") + "##{uri.fragment}".chomp("#")
+        path = path_without_leading_slashes(uri)
+        "#{path}?#{uri.query}".chomp("?") + "##{uri.fragment}".chomp("#")
       end
+    end
+
+    # @api private
+    def path_without_leading_slashes(uri)
+      uri.path.sub(/\A\/+/, "/")
     end
 
     # @api private

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -58,6 +58,19 @@ describe Clearance::SessionsController do
     end
 
     context "with good credentials and a session return url" do
+      it "redirects to the return URL removing leading slashes" do
+        user = create(:user)
+        url = "/url_in_the_session?foo=bar#baz"
+        return_url = "//////#{url}"
+        request.session[:return_to] = return_url
+
+        post :create, params: {
+          session: { email: user.email, password: user.password },
+        }
+
+        should redirect_to(url)
+      end
+
       it "redirects to the return URL maintaining query and fragment" do
         user = create(:user)
         return_url = "/url_in_the_session?foo=bar#baz"


### PR DESCRIPTION
An open redirect can be possible when users are able to set the value of
session[:return_to]. If the value used for return_to contains multiple
leading slashes (/////example.com) the user ends up being redirected the
external domain that comes after the slashes (http://example.com).

To fix this issue, extra sanitization was added when processing the
return_to url, removing multiple leading slashes to avoid the open
redirect.