### PR TITLE
Documentation - Update SignInGuard information

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,7 @@ end
 ```
 
 ```ruby
+# app/guards/email_confirmation_guard.rb (or somehwere else it will be auto-loaded)
 class EmailConfirmationGuard < Clearance::SignInGuard
   def call
     if unconfirmed?

--- a/README.md
+++ b/README.md
@@ -349,7 +349,7 @@ end
 ```
 
 ```ruby
-# app/guards/email_confirmation_guard.rb (or somehwere else it will be auto-loaded)
+# app/guards/email_confirmation_guard.rb
 class EmailConfirmationGuard < Clearance::SignInGuard
   def call
     if unconfirmed?

--- a/lib/clearance/sign_in_guard.rb
+++ b/lib/clearance/sign_in_guard.rb
@@ -19,7 +19,7 @@ module Clearance
   #       config.sign_in_guards = ["ConfirmationGuard"]
   #     end
   #
-  #     # in app/guards/confirmation_guard.rb (or another path that is auto-loaded)
+  #     # in app/guards/confirmation_guard.rb (or another auto-loaded path)
   #     class ConfirmationGuard < Clearance::SignInGuard
   #       def call
   #         if signed_in? && current_user.email_confirmed?

--- a/lib/clearance/sign_in_guard.rb
+++ b/lib/clearance/sign_in_guard.rb
@@ -19,7 +19,7 @@ module Clearance
   #       config.sign_in_guards = ["ConfirmationGuard"]
   #     end
   #
-  #     # in lib/guards/confirmation_guard.rb
+  #     # in app/guards/confirmation_guard.rb (or another path that is auto-loaded)
   #     class ConfirmationGuard < Clearance::SignInGuard
   #       def call
   #         if signed_in? && current_user.email_confirmed?

--- a/lib/clearance/sign_in_guard.rb
+++ b/lib/clearance/sign_in_guard.rb
@@ -16,7 +16,7 @@ module Clearance
   #
   #     # in config/initializers/clearance.rb
   #     Clearance.configure do |config|
-  #       config.sign_in_guards = [ConfirmationGuard]
+  #       config.sign_in_guards = ["ConfirmationGuard"]
   #     end
   #
   #     # in lib/guards/confirmation_guard.rb

--- a/lib/clearance/sign_in_guard.rb
+++ b/lib/clearance/sign_in_guard.rb
@@ -19,7 +19,7 @@ module Clearance
   #       config.sign_in_guards = ["ConfirmationGuard"]
   #     end
   #
-  #     # in app/guards/confirmation_guard.rb (or another auto-loaded path)
+  #     # in app/guards/confirmation_guard.rb
   #     class ConfirmationGuard < Clearance::SignInGuard
   #       def call
   #         if signed_in? && current_user.email_confirmed?


### PR DESCRIPTION
As per #891, sign in guards should be specified as strings since Rails 6 and the move to Zeitwerk (update comment in `lib/clearance/sign_in_guard.rb`.)

Additionally, guards in the suggested location (`lib/guards`) don't auto-load for me in Rails 7.0.0.alpha2 (didn't check earlier versions). I propose changing the location in the same file and an addition to the README to help newbies figure out a reasonable folder to build a guardhouse.

Related, [Tute's blog post](https://thoughtbot.com/blog/email-confirmation-with-clearance) could do with a revision now too:

```
  Clearance.configure do |config|
    config.routes = false
-   config.sign_in_guards = [ConfirmedUserGuard]
+   config.sign_in_guards = ["ConfirmedUserGuard"]
  end
```