### PR TITLE
Pass options through to `redirect_to`

### DIFF
--- a/lib/clearance/authorization.rb
+++ b/lib/clearance/authorization.rb
@@ -77,8 +77,8 @@ module Clearance
     end
 
     # @api private
-    def redirect_back_or(default)
-      redirect_to(return_to || default)
+    def redirect_back_or(default, options = {})
+      redirect_to(return_to || default, options)
       clear_return_to
     end
 


### PR DESCRIPTION
Use case: allow setting a flash message when using `redirect_back_or` with a SignInGuard to require email confirmation (based on https://thoughtbot.com/blog/email-confirmation-with-clearance):

```
class UsersController < Clearance::UsersController
  def create
    @user = user_from_params
    @user.email_confirmation_token = Clearance::Token.new

    if @user.save
      UserMailer.confirm_email(@user).deliver_later
      redirect_back_or url_after_create, notice: t("flashes.confirmation_pending")
#                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    else
      render template: "users/new"
    end
  end
end
```

This implementation Works On My Machine™ but after reading [how redirect_to is implemented](https://apidock.com/rails/v6.1.3.1/ActionController/Redirecting/redirect_to) I'm still kind of not sure how this works so it's probably naïve, fragile, dangerous or all three.

This allows me to show a flash message like "Sign up request received. Please check your email."

Apologies if there's a better way of achieving this.