### PR TITLE
Add config option to disable signin after password reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Clearance.configure do |config|
   config.sign_in_guards = []
   config.user_model = "User"
   config.parent_controller = "ApplicationController"
+  config.sign_in_on_password_reset = false
 end
 ```
 

--- a/app/controllers/clearance/passwords_controller.rb
+++ b/app/controllers/clearance/passwords_controller.rb
@@ -33,7 +33,7 @@ class Clearance::PasswordsController < Clearance::BaseController
     @user = find_user_for_update
 
     if @user.update_password(password_from_password_reset_params)
-      sign_in @user
+      sign_in @user if Clearance.configuration.sign_in_on_password_reset?
       redirect_to url_after_update
       session[:password_reset_token] = nil
     else

--- a/lib/clearance/configuration.rb
+++ b/lib/clearance/configuration.rb
@@ -118,6 +118,12 @@ module Clearance
     # @return [Array<String>]
     attr_accessor :allowed_backdoor_environments
 
+    # Controls wether users are automatically signed in after successfully
+    # resetting their password.
+    # Defaults to `true`.
+    # @return [Boolean]
+    attr_writer :sign_in_on_password_reset
+
     def initialize
       @allow_sign_up = true
       @allowed_backdoor_environments = ["test", "ci", "development"]
@@ -134,6 +140,7 @@ module Clearance
       @secure_cookie = false
       @signed_cookie = false
       @sign_in_guards = []
+      @sign_in_on_password_reset = true
     end
 
     def signed_cookie=(value)
@@ -213,6 +220,10 @@ module Clearance
 
     def rotate_csrf_on_sign_in?
       !!rotate_csrf_on_sign_in
+    end
+
+    def sign_in_on_password_reset?
+      @sign_in_on_password_reset
     end
   end
 

--- a/spec/requests/password_maintenance_spec.rb
+++ b/spec/requests/password_maintenance_spec.rb
@@ -2,17 +2,36 @@ require "spec_helper"
 
 describe "Password maintenance" do
   context "when updating the password" do
-    it "signs the user in and redirects" do
-      user = create(:user, :with_forgotten_password)
+    let(:user) { create(:user, :with_forgotten_password) }
+
+    before(:each) do
+      Clearance.configure do |config|
+        config.sign_in_on_password_reset = sign_in_on_password_reset
+      end
 
       put user_password_url(user), params: {
         user_id: user,
         token: user.confirmation_token,
         password_reset: { password: "my_new_password" },
       }
+    end
 
-      expect(response).to redirect_to(Clearance.configuration.redirect_url)
-      expect(cookies["remember_token"]).to be_present
+    context "if `sign_in_on_password_reset` option is true" do
+      let(:sign_in_on_password_reset) { true }
+
+      it "signs the user in and redirects" do
+        expect(response).to redirect_to(Clearance.configuration.redirect_url)
+        expect(cookies["remember_token"]).to be_present
+      end
+    end
+
+    context "if `sign_in_on_password_reset` option is false" do
+      let(:sign_in_on_password_reset) { false }
+
+      it "redirects, but does not sign in the user" do
+        expect(response).to redirect_to(Clearance.configuration.redirect_url)
+        expect(cookies["remember_token"]).not_to be_present
+      end
     end
   end
 end


### PR DESCRIPTION
Right now, users are automatically signed in after resetting their password. However, for some use cases, it might make sense that they have to sign in explicitly.

For example, in an app we’re building, we have implemented 2FA on top of Clearance. After a password reset, we want users to sign in themselves using the second factor. Otherwise, password resets could be used to circumvent 2FA. (While we could ask for the second factor before resetting the password, we decided to allow password resets without the second factor, but then force users to sign in.)

This PR adds a new configuration option to Clearance, `sign_in_on_password_reset`. It defaults to `true`, i.e. the default behavior does not change.

Closes #949.