### PR TITLE
Bump Ruby patch versions on GitHub Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,15 +22,15 @@ jobs:
           - "6.0"
           - "6.1"
         ruby:
-          - "2.4.9"
-          - "2.5.7"
-          - "2.6.5"
-          - "2.7.2"
+          - "2.4.10"
+          - "2.5.9"
+          - "2.6.9"
+          - "2.7.5"
         exclude:
           - gemfile: "6.0"
-            ruby: "2.4.9"
+            ruby: "2.4.10"
           - gemfile: "6.1"
-            ruby: "2.4.9"
+            ruby: "2.4.10"
 
     env:
       BUNDLE_GEMFILE: gemfiles/rails_${{ matrix.gemfile }}.gemfile


### PR DESCRIPTION
Using the latest Ruby patch version for each release gives a better visibility about the Rails (and other gems) compatibility for each of them, as deprecation warnings are added when new minor or major versions are planned.