### PR TITLE
Replace text_field with email_field

### DIFF
--- a/app/views/passwords/new.html.erb
+++ b/app/views/passwords/new.html.erb
@@ -6,7 +6,7 @@
   <%= form_for :password, url: passwords_path do |form| %>
     <div class="text-field">
       <%= form.label :email %>
-      <%= form.text_field :email, type: 'email' %>
+      <%= form.email_field :email %>
     </div>
 
     <div class="submit-field">

--- a/app/views/sessions/_form.html.erb
+++ b/app/views/sessions/_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_for :session, url: session_path do |form| %>
   <div class="text-field">
     <%= form.label :email %>
-    <%= form.text_field :email, type: 'email' %>
+    <%= form.email_field :email %>
   </div>
 
   <div class="password-field">

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -1,6 +1,6 @@
 <div class="text-field">
   <%= form.label :email %>
-  <%= form.text_field :email, type: 'email' %>
+  <%= form.email_field :email %>
 </div>
 
 <div class="password-field">


### PR DESCRIPTION
This small change replaces `form.text_field :email, type: 'email'` with `form.email_field :email` in all of the views used in the generators.