### PR TITLE
Update the expect_user_to_be_signed_out helper

### DIFF
--- a/lib/generators/clearance/specs/templates/support/features/clearance_helpers.rb
+++ b/lib/generators/clearance/specs/templates/support/features/clearance_helpers.rb
@@ -36,6 +36,7 @@ module Features
     end
 
     def expect_user_to_be_signed_out
+      visit root_path
       expect(page).to have_content I18n.t("layouts.application.sign_in")
     end
 


### PR DESCRIPTION
Currently the `expect_user_to_be_signed_out` helper expects
to have a sign_in button on the current page, however,
this causes the `visitor_updates_password_spec.rb` to fail
since the sign_in button is not present on the password reset page.

This PR updated the `expect_user_to_be_signed_out` helper to follow the same approach as `expect_user_to_be_signed_in` by visiting the `root_path` first then checking if the user is signed out

would it be better to add a `sign_in` button in the `passwords/new.html.erb` view instead?