### PR TITLE
Fix return type in documentation

### DIFF
--- a/lib/clearance/user.rb
+++ b/lib/clearance/user.rb
@@ -234,7 +234,7 @@ module Clearance
     # Always false. Override this method in your user model to allow for other
     # forms of user authentication (username, Facebook, etc).
     #
-    # @return [false]
+    # @return [Boolean]
     def email_optional?
       false
     end
@@ -242,7 +242,7 @@ module Clearance
     # Always false. Override this method in your user model to allow for other
     # forms of user authentication (username, Facebook, etc).
     #
-    # @return [false]
+    # @return [Boolean]
     def password_optional?
       false
     end


### PR DESCRIPTION
The `email_optional?` and `password_optional?` methods can be overridden to return true so the return type should not be hard-coded to `false`.