### PR TITLE
Supports Turbo with appropriate status codes

### DIFF
--- a/app/controllers/clearance/passwords_controller.rb
+++ b/app/controllers/clearance/passwords_controller.rb
@@ -15,7 +15,7 @@ class Clearance::PasswordsController < Clearance::BaseController
       deliver_email(user)
     end
 
-    render template: "passwords/create"
+    render template: "passwords/create", status: :accepted
   end
 
   def edit
@@ -34,7 +34,7 @@ class Clearance::PasswordsController < Clearance::BaseController
 
     if @user.update_password(password_from_password_reset_params)
       sign_in @user
-      redirect_to url_after_update
+      redirect_to url_after_update, status: :see_other
       session[:password_reset_token] = nil
     else
       flash_failure_after_update
@@ -80,14 +80,14 @@ class Clearance::PasswordsController < Clearance::BaseController
   def ensure_email_present
     if email_from_password_params.blank?
       flash_failure_when_missing_email
-      render template: "passwords/new"
+      render template: "passwords/new", status: :unprocessable_entity
     end
   end
 
   def ensure_existing_user
     unless find_user_by_id_and_confirmation_token
       flash_failure_when_forbidden
-      render template: "passwords/new"
+      render template: "passwords/new", status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/clearance/sessions_controller.rb
+++ b/app/controllers/clearance/sessions_controller.rb
@@ -17,7 +17,7 @@ class Clearance::SessionsController < Clearance::BaseController
 
   def destroy
     sign_out
-    redirect_to url_after_destroy
+    redirect_to url_after_destroy, status: :see_other
   end
 
   def new

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -117,6 +117,7 @@ describe Clearance::SessionsController do
       end
 
       it { should redirect_to_url_after_destroy }
+      it { expect(response).to have_http_status(:see_other) }
     end
 
     context "with a cookie" do

--- a/spec/requests/password_maintenance_spec.rb
+++ b/spec/requests/password_maintenance_spec.rb
@@ -12,6 +12,7 @@ describe "Password maintenance" do
       }
 
       expect(response).to redirect_to(Clearance.configuration.redirect_url)
+      expect(response).to have_http_status(:see_other)
       expect(cookies["remember_token"]).to be_present
     end
   end


### PR DESCRIPTION
"200 OK" responses are not re-rendered when Turbo is enabled.

Sending the right status code will trigger the page to be replaced.

This does change the status codes that Clearance returns.