### PR TITLE
Add unique constraints on remember_token and confirmation_token

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -23,6 +23,6 @@ ActiveRecord::Schema.define(version: 20110111224543) do
   end
 
   add_index "users", ["email"], name: "index_users_on_email"
-  add_index "users", ["remember_token"], name: "index_users_on_remember_token"
-
+  add_index "users", ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
+  add_index "users", ["remember_token"], name: "index_users_on_remember_token", unique: true
 end

--- a/lib/generators/clearance/install/install_generator.rb
+++ b/lib/generators/clearance/install/install_generator.rb
@@ -73,17 +73,21 @@ module Clearance
 
       def new_columns
         @new_columns ||= {
-          email: 't.string :email',
-          encrypted_password: 't.string :encrypted_password, limit: 128',
-          confirmation_token: 't.string :confirmation_token, limit: 128',
-          remember_token: 't.string :remember_token, limit: 128'
+          email: "t.string :email",
+          encrypted_password: "t.string :encrypted_password, limit: 128",
+          confirmation_token: "t.string :confirmation_token, limit: 128",
+          remember_token: "t.string :remember_token, limit: 128",
         }.reject { |column| existing_users_columns.include?(column.to_s) }
       end
 
       def new_indexes
         @new_indexes ||= {
-          index_users_on_email: 'add_index :users, :email',
-          index_users_on_remember_token: 'add_index :users, :remember_token'
+          index_users_on_email:
+            "add_index :users, :email",
+          index_users_on_confirmation_token:
+            "add_index :users, :confirmation_token, unique: true",
+          index_users_on_remember_token:
+            "add_index :users, :remember_token, unique: true",
         }.reject { |index| existing_users_indexes.include?(index.to_s) }
       end
 

--- a/lib/generators/clearance/install/templates/db/migrate/add_clearance_to_users.rb.erb
+++ b/lib/generators/clearance/install/templates/db/migrate/add_clearance_to_users.rb.erb
@@ -1,35 +1,34 @@
 class AddClearanceToUsers < ActiveRecord::Migration<%= migration_version %>
   def self.up
+<% if config[:new_columns].any? -%>
     change_table :users do |t|
 <% config[:new_columns].values.each do |column| -%>
       <%= column %>
 <% end -%>
     end
-
+<% end -%>
+<% if config[:new_indexes].any? -%>
 <% config[:new_indexes].values.each do |index| -%>
     <%= index %>
 <% end -%>
-
-    users = select_all("SELECT id FROM users WHERE remember_token IS NULL")
-
-    users.each do |user|
-      update <<-SQL.squish
-        UPDATE users
-        SET remember_token = '#{Clearance::Token.new}'
-        WHERE id = '#{user['id']}'
-      SQL
+<% end -%>
+<% if config[:new_columns].keys.include?(:remember_token) -%>
+    Clearance.configuration.user_model.where(remember_token: nil).each do |user|
+      user.update_columns(remember_token: Clearance::Token.new)
     end
+<% end -%>
   end
 
-  def self.down                     
+  def self.down
 <% config[:new_indexes].values.each do |index| -%>
-    <%= index.gsub("add_index", "remove_index") %>
+    <%= index.sub("add_index", "remove_index") %>
 <% end -%>
-           
-    change_table :users do |t|
 <% if config[:new_columns].any? -%>
-      t.remove <%= new_columns.keys.map { |column| ":#{column}" }.join(", ") %>
+    change_table :users do |t|
+<% config[:new_columns].keys.each do |key| -%>
+      t.remove <%= key.inspect %>
 <% end -%>
     end
+<% end -%>
   end
 end

--- a/lib/generators/clearance/install/templates/db/migrate/create_users.rb.erb
+++ b/lib/generators/clearance/install/templates/db/migrate/create_users.rb.erb
@@ -9,6 +9,7 @@ class CreateUsers < ActiveRecord::Migration<%= migration_version %>
     end
 
     add_index :users, :email
-    add_index :users, :remember_token
+    add_index :users, :confirmation_token, unique: true
+    add_index :users, :remember_token, unique: true
   end
 end

--- a/spec/generators/clearance/install/install_generator_spec.rb
+++ b/spec/generators/clearance/install/install_generator_spec.rb
@@ -135,6 +135,12 @@ describe Clearance::Generators::InstallGenerator, :generator do
         expect(migration).to contain("add_index :users, :email")
         expect(migration).not_to contain("t.string :remember_token")
         expect(migration).not_to contain("add_index :users, :remember_token")
+        expect(migration).to(
+          contain("add_index :users, :confirmation_token, unique: true"),
+        )
+        expect(migration).to(
+          contain("remove_index :users, :confirmation_token, unique: true"),
+        )
       end
     end
   end


### PR DESCRIPTION
This is useful to prevent eventual collisions, possibly when the
application is not using a great random string generator.

For reference Clearance random string implementation is:

```ruby
SecureRandom.hex(20).encode('UTF-8')
```

Adding unique indexes prevents eventual collisions.

This is for new applications, existing applications can still have
duplicate tokens (they will be scoped by user_id during the lookup).