### PR TITLE
Forward options in redirect_back_or helper

### DIFF
--- a/lib/clearance/authorization.rb
+++ b/lib/clearance/authorization.rb
@@ -77,8 +77,8 @@ module Clearance
     end
 
     # @api private
-    def redirect_back_or(default)
-      redirect_to(return_to || default)
+    def redirect_back_or(default, **options)
+      redirect_to(return_to || default, **options)
       clear_return_to
     end
 


### PR DESCRIPTION
Examples:

```ruby
redirect_back_or root_path, notice: "Redirected to homepage"
redirect_back_or root_path, status: :see_other
```

Co-authored-by: Bryan Marble <bryan@5or7.com>