### PR TITLE
Add configuration option to disable sign in after password reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Clearance.configure do |config|
   config.sign_in_guards = []
   config.user_model = "User"
   config.parent_controller = "ApplicationController"
+  config.sign_in_on_password_reset = false
 end
 ```
 

--- a/app/controllers/clearance/passwords_controller.rb
+++ b/app/controllers/clearance/passwords_controller.rb
@@ -33,7 +33,7 @@ class Clearance::PasswordsController < Clearance::BaseController
     @user = find_user_for_update
 
     if @user.update_password(password_from_password_reset_params)
-      sign_in @user
+      sign_in @user if Clearance.configuration.sign_in_on_password_reset?
       redirect_to url_after_update, status: :see_other
       session[:password_reset_token] = nil
     else

--- a/lib/clearance/configuration.rb
+++ b/lib/clearance/configuration.rb
@@ -123,6 +123,12 @@ module Clearance
     # @return [Symbol]
     attr_accessor :user_parameter
 
+    # Controls wether users are automatically signed in after successfully
+    # resetting their password.
+    # Defaults to `true`.
+    # @return [Boolean]
+    attr_writer :sign_in_on_password_reset
+
     def initialize
       @allow_sign_up = true
       @allowed_backdoor_environments = ["test", "ci", "development"]
@@ -140,6 +146,7 @@ module Clearance
       @signed_cookie = false
       @sign_in_guards = []
       @user_parameter = nil
+      @sign_in_on_password_reset = true
     end
 
     def signed_cookie=(value)
@@ -219,6 +226,10 @@ module Clearance
 
     def rotate_csrf_on_sign_in?
       !!rotate_csrf_on_sign_in
+    end
+
+    def sign_in_on_password_reset?
+      @sign_in_on_password_reset
     end
   end
 


### PR DESCRIPTION
In some cases you may not want the user to be signed in after a password
reset, e.g. when implementing multi-factor authentication.

Now you can disable sign in after a successful password reset with the
`sign_in_on_password_reset` configuration option.

To prevent side-effects, this configuration option is set to `true` by
default.

Co-authored-by: Till Prochaska <mail@tillprochaska.de>