### PR TITLE
fix validating email in strict mode

### DIFF
--- a/lib/clearance/user.rb
+++ b/lib/clearance/user.rb
@@ -150,7 +150,7 @@ module Clearance
 
       included do
         validates :email,
-          email: { strict_mode: true },
+          email: { mode: :strict },
           presence: true,
           uniqueness: { allow_blank: true, case_sensitive: true },
           unless: :email_optional?

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -5,15 +5,13 @@ describe User do
   it { is_expected.to have_db_index(:remember_token) }
   it { is_expected.to validate_presence_of(:email) }
   it { is_expected.to validate_presence_of(:password) }
-  it { is_expected.to allow_value("foo;@example.com").for(:email) }
-  it { is_expected.to allow_value("foo@.example.com").for(:email) }
-  it { is_expected.to allow_value("foo@example..com").for(:email) }
   it { is_expected.to allow_value("foo@example.co.uk").for(:email) }
   it { is_expected.to allow_value("foo@example.com").for(:email) }
   it { is_expected.to allow_value("foo+bar@example.com").for(:email) }
   it { is_expected.not_to allow_value("example.com").for(:email) }
   it { is_expected.not_to allow_value("foo").for(:email) }
   it { is_expected.not_to allow_value("foo@").for(:email) }
+  it { is_expected.not_to allow_value("foo@bar").for(:email) }
 
   describe "#email" do
     it "stores email in down case and removes whitespace" do


### PR DESCRIPTION
To enable strict mode in email validation, [`mode: :strict` should be used](https://github.com/K-and-R/email_validator#strict-mode), not `strict_mode: true`. Maybe it used to be `strict_mode: true` with an earlier version of the `email_validator` gem?
Be that as it is, it seems that the `strict_mode` parameter is ignored and `loose` validation is used.

Now, with strict mode turned on, emails like foo;@example.com, foo@.example.com or foo@example..com are no longer valid, so I removed the specs. Why were they expected to be valid until now? I'm not an expert in that matter, but they look pretty invalid to me. 😸