### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Clearance.configure do |config|
   config.redirect_url = "/"
   config.rotate_csrf_on_sign_in = true
   config.same_site = nil
-  config.secure_cookie = false
+  config.secure_cookie = Rails.configuration.force_ssl
   config.signed_cookie = false
   config.sign_in_guards = []
   config.user_model = "User"


### PR DESCRIPTION
Recommend checking against `Rails.configuration.force_ssl` boolean value in the example configuration.  That way it is off in development & test environment by default.