### PR TITLE
Explain how to use the testing backdoor outside of Rails routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,6 +393,12 @@ Usage:
 visit root_path(as: user)
 ```
 
+You can even use the backdoor outside of Rails route helpers:
+
+```ruby
+visit "/dashboard?as=#{user.id}"
+```
+
 Additionally, if `User#to_param` is overridden, you can pass a block in
 order to override the default behavior:
 


### PR DESCRIPTION
Some projects may want to use the backdoor, but may not be using Rails routes in their system tests. One example is an app that hosts a React frontend, but still uses Clearance cookies for auth. A system test with Capybara may visit a React route like this: `visit "/payment_method"`. 

The existing documentation didn't show how to use the backdoor with this kind of route.