### PR TITLE
use Strong Parameters on User model user_params method

### DIFF
--- a/app/controllers/clearance/users_controller.rb
+++ b/app/controllers/clearance/users_controller.rb
@@ -31,16 +31,10 @@ class Clearance::UsersController < Clearance::BaseController
   end
 
   def user_from_params
-    email = user_params.delete(:email)
-    password = user_params.delete(:password)
-
-    Clearance.configuration.user_model.new(user_params).tap do |user|
-      user.email = email
-      user.password = password
-    end
+    Clearance.configuration.user_model.new(user_params)
   end
 
   def user_params
-    params[Clearance.configuration.user_parameter] || Hash.new
+    params.fetch(Clearance.configuration.user_parameter, {}).permit(:email, :password)
   end
 end


### PR DESCRIPTION
This PR suggests 2 small improvements:
- always return ActionParam object on `UsersController` `user_params` method (even if empty)
- use Rails Strong Parameters to permit default user params instead of deleting params entries

this way we can easily override `user_params` method to add new custom fields for User model

let me know if it makes sense to add a configuration entry for changing default new User parameters, for example:
as default: `Clearance.configuration.permit_user_parameters = [:email, :password]`

we could customize it:
`Clearance.configuration.permit_user_parameters = [:name, :email, :password]`

and default permit call would looks like:
`params.fetch(Clearance.configuration.user_parameter, {}).permit(*Clearance.configuration.permit_user_parameters)`
