### PR TITLE
Only overwrite QUERY_STRING if as param present

### DIFF
--- a/lib/clearance/back_door.rb
+++ b/lib/clearance/back_door.rb
@@ -50,9 +50,9 @@ module Clearance
     def sign_in_through_the_back_door(env)
       params = Rack::Utils.parse_query(env["QUERY_STRING"])
       user_param = params.delete("as")
-      env["QUERY_STRING"] = Rack::Utils.build_query(params)
 
       if user_param.present?
+        env["QUERY_STRING"] = Rack::Utils.build_query(params)
         user = find_user(user_param)
         env[:clearance].sign_in(user)
       end


### PR DESCRIPTION
* This middleware deletes the as param from the query params if present
  to find the user to sign in. We should only overwrite
  env["QUERY_STRING"] if the as param is present.
* Move line that overwrites env["QUERY_STRING"] inside the
  if user_param.present? so that it will only be overwritten if
  we have deleted the as param.
