### PR TITLE
Prefer an already initialized hash instead of new one creation

### DIFF
--- a/app/controllers/clearance/users_controller.rb
+++ b/app/controllers/clearance/users_controller.rb
@@ -41,6 +41,6 @@ class Clearance::UsersController < Clearance::BaseController
   end
 
   def user_params
-    params[Clearance.configuration.user_parameter] || Hash.new
+    params[Clearance.configuration.user_parameter] || {}
   end
 end

--- a/lib/clearance/session.rb
+++ b/lib/clearance/session.rb
@@ -185,10 +185,8 @@ module Clearance
 
     # @api private
     def delete_cookie_options
-      Hash.new.tap do |options|
-        if configured_cookie_domain
-          options[:domain] = domain
-        end
+      {}.tap do |options|
+        options[:domain] = domain if configured_cookie_domain
       end
     end
 


### PR DESCRIPTION
Using an already initialized hash is better than initializing a new one because using an already initialized hash takes less time than initializing a new one. Even [Rubocop](https://github.com/rubocop/ruby-style-guide#literal-array-hash) talks about it.

<img width="854" alt="Screenshot 2022-10-13 at 08 35 44" src="https://user-images.githubusercontent.com/49816584/195510376-187ad7b9-aee2-43fb-b761-a9261cde2f68.png">
