### PR TITLE
update argon2 to v2.2.0 due to errors loading argon2_wrap library

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,8 +59,8 @@ GEM
       bundler
       rake
       thor (>= 0.14.0)
-    argon2 (2.1.1)
-      ffi (~> 1.14)
+    argon2 (2.2.0)
+      ffi (~> 1.15)
       ffi-compiler (~> 1.0)
     ast (2.4.2)
     bcrypt (3.1.18)


### PR DESCRIPTION
happens with rubygems 3.4 and was discussed at: https://github.com/technion/ruby-argon2/issues/56

I just ran `rake spec` locally with ruby 3.1.2p20 and rubygems 3.4.6 and they pass, but i could be missing some more elaborate tests.