### PR TITLE
Remove obsolete references to MiniTest

### DIFF
--- a/lib/clearance/testing/deny_access_matcher.rb
+++ b/lib/clearance/testing/deny_access_matcher.rb
@@ -90,7 +90,7 @@ module Clearance
             @failure_message_when_negated <<
               "Didn't expect to redirect to #{@url}."
             true
-          rescue MiniTest::Assertion, ::Test::Unit::AssertionFailedError
+          rescue Minitest::Assertion, ::Test::Unit::AssertionFailedError
             @failure_message << "Expected to redirect to #{@url} but did not."
             false
           end


### PR DESCRIPTION
Use of "MiniTest" (vs modern "Minitest") was removed in version 5.19.0. CI runs using version 5.20 of Minitest and was failing.

This commit replaces the use of "MiniTest" with "Minitest".

https://my.diffend.io/gems/minitest/5.18.1/5.19.0