### PR TITLE
Add specs for email validator strict mode

### DIFF
--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -12,6 +12,9 @@ describe User do
   it { is_expected.not_to allow_value("foo").for(:email) }
   it { is_expected.not_to allow_value("foo@").for(:email) }
   it { is_expected.not_to allow_value("foo@bar").for(:email) }
+  it { is_expected.not_to allow_value("foo;@example.com").for(:email) }
+  it { is_expected.not_to allow_value("foo@.example.com").for(:email) }
+  it { is_expected.not_to allow_value("foo@example..com").for(:email) }
 
   describe "#email" do
     it "stores email in down case and removes whitespace" do


### PR DESCRIPTION
Strict mode for the email validator is not being enforced due to providing incorrect configuration.