### PR TITLE
Add configuration options for failure method redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ Clearance.configure do |config|
   config.mailer_sender = "reply@example.com"
   config.password_strategy = Clearance::PasswordStrategies::BCrypt
   config.redirect_url = "/"
+  config.url_after_destroy = nil
+  config.url_after_denied_access_when_signed_out = nil
   config.rotate_csrf_on_sign_in = true
   config.same_site = nil
   config.secure_cookie = false
@@ -222,8 +224,16 @@ These "failure" methods are called for signed out sessions:
 - `application#url_after_denied_access_when_signed_out`
 - `sessions#url_after_destroy`
 
-They both default to `sign_in_url`. Override this method to change both of their
-behavior, or override them individually to just change one.
+You can override the appropriate method in your subclassed controller or you
+can set a configuration value for either of these URLs:
+
+- `Clearance.configuration.url_after_denied_access_when_signed_out`
+- `Clearance.configuration.url_after_destroy`
+
+Both configurations default to `nil` and if not set will default to
+`sign_in_url` in `sessions_controller.rb` and `authorization.rb` for backwards
+compatibility.
+
 
 ### Views
 

--- a/app/controllers/clearance/sessions_controller.rb
+++ b/app/controllers/clearance/sessions_controller.rb
@@ -37,7 +37,7 @@ class Clearance::SessionsController < Clearance::BaseController
   end
 
   def url_after_destroy
-    sign_in_url
+    Clearance.configuration.url_after_destroy || sign_in_url
   end
 
   def url_for_signed_in_users

--- a/lib/clearance/authorization.rb
+++ b/lib/clearance/authorization.rb
@@ -114,7 +114,7 @@ module Clearance
     #
     # @return [String]
     def url_after_denied_access_when_signed_out
-      sign_in_url
+      Clearance.configuration.url_after_denied_access_when_signed_out || sign_in_url
     end
   end
 end

--- a/lib/clearance/configuration.rb
+++ b/lib/clearance/configuration.rb
@@ -68,6 +68,20 @@ module Clearance
     # @return [String]
     attr_accessor :redirect_url
 
+    # The default path Clearance will redirect signed out users to.
+    # Defaults to `nil` so that the controller will use `sign_in_url`
+    # for backwards compatibility. This can be set here instead of overriding
+    # the method via an overridden session controller.
+    # @return [String]
+    attr_accessor :url_after_destroy
+
+    # The default path Clearance will redirect non-users to when denied access.
+    # Defaults to `nil` so that the authorization module will use `sign_in_url`
+    # for backwards compatibility. This can be set here instead of overriding
+    # the method via an overridden authorization module.
+    # @return [String]
+    attr_accessor :url_after_denied_access_when_signed_out
+
     # Controls whether Clearance will rotate the CSRF token on sign in.
     # Defaults to `nil` which generates a warning. Will default to true in
     # Clearance 2.0.
@@ -140,6 +154,8 @@ module Clearance
       @same_site = nil
       @mailer_sender = 'reply@example.com'
       @redirect_url = '/'
+      @url_after_destroy = nil
+      @url_after_denied_access_when_signed_out = nil
       @rotate_csrf_on_sign_in = true
       @routes = true
       @secure_cookie = false

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -109,6 +109,34 @@ describe Clearance::Configuration do
     end
   end
 
+  context "when no url_after_destroy value specified" do
+    it "returns nil as the default" do
+      expect(Clearance::Configuration.new.url_after_destroy).to be_nil
+    end
+  end
+
+  context "when url_after_destroy value is specified" do
+    it "returns the url_after_destroy value" do
+      Clearance.configure { |config| config.url_after_destroy = "/redirect" }
+
+      expect(Clearance.configuration.url_after_destroy).to eq "/redirect"
+    end
+  end
+
+  context "when no url_after_denied_access_when_signed_out value specified" do
+    it "returns nil as the default" do
+      expect(Clearance::Configuration.new.url_after_denied_access_when_signed_out).to be_nil
+    end
+  end
+
+  context "when url_after_denied_access_when_signed_out value is specified" do
+    it "returns the url_after_denied_access_when_signed_out value" do
+      Clearance.configure { |config| config.url_after_denied_access_when_signed_out = "/redirect" }
+
+      expect(Clearance.configuration.url_after_denied_access_when_signed_out).to eq "/redirect"
+    end
+  end
+
   context "when specifying sign in guards" do
     it "returns the stack with added guards" do
       DummyGuard = Class.new

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -118,6 +118,12 @@ describe Clearance::SessionsController do
   end
 
   describe "on DELETE to #destroy" do
+    let(:configured_redirect_url) { nil }
+
+    before do
+      Clearance.configure { |config| config.url_after_destroy = configured_redirect_url }
+    end
+
     context "given a signed out user" do
       before do
         sign_out
@@ -126,6 +132,12 @@ describe Clearance::SessionsController do
 
       it { should redirect_to_url_after_destroy }
       it { expect(response).to have_http_status(:see_other) }
+
+      context "when the custom redirect URL is set" do
+        let(:configured_redirect_url) { "/redirected" }
+
+        it { should redirect_to(configured_redirect_url) }
+      end
     end
 
     context "with a cookie" do
@@ -144,6 +156,12 @@ describe Clearance::SessionsController do
 
       it "should unset the current user" do
         expect(request.env[:clearance].current_user).to be_nil
+      end
+
+      context "when the custom redirect URL is set" do
+        let(:configured_redirect_url) { "/redirected" }
+
+        it { should redirect_to(configured_redirect_url) }
       end
     end
   end


### PR DESCRIPTION
This PR introduces two new accessor values in the Configuration class:
  * `url_after_destroy`
  * `url_after_denied_access_when_signed_out`

These both default to `nil` and their usage defaults to the prior value of `sign_in_url` so that this will be nicely backwards-compatible.

### Rationale
I started a new project and found myself subclassing the `sessions_controller.rb` only so I can override `url_after_destroy`. And it seemed odd that `url_after_create` uses a configuration value but `url_after_destroy` does not.

https://github.com/thoughtbot/clearance/blob/630f1752f4d6e9a186dc511cccd5a5819a5f3077/app/controllers/clearance/sessions_controller.rb#L35-L41

I did the same for `url_after_denied_access_when_signed_out` for completeness' sake.

Note that both of these places will still default to `sign_in_url` if nothing is set. Also, I didn't see any direct unit specs for the authorization module or even the `url_after_denied_access_when_signed_out`