### PR TITLE
Revert "Replace APOSTROPHE with RIGHT SINGLE QUOTATION MARK in locale"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,6 @@ complete changelog, see the git history for each version via the version links.
 
 ## [Unreleased]
 
-- Replace APOSTROPHE (U+0027) with RIGHT SINGLE QUOTATION MARK (U+2019) in locale.
-See https://github.com/rails/rails/pull/45463
-
 [Unreleased]: https://github.com/thoughtbot/clearance/compare/v2.6.2...main
 
 ## [2.6.2] January 15, 2024

--- a/config/locales/clearance.en.yml
+++ b/config/locales/clearance.en.yml
@@ -6,18 +6,18 @@ en:
         change_password: Change your password
   clearance_mailer:
     change_password:
-      closing: If you didn’t request this, ignore this email. Your password has
+      closing: If you didn't request this, ignore this email. Your password has
         not been changed.
       link_text: Change my password
       opening: "Someone, hopefully you, requested we send you a link to change
         your password:"
   flashes:
     failure_after_create: Bad email or password.
-    failure_after_update: Password can’t be blank.
+    failure_after_update: Password can't be blank.
     failure_when_forbidden: Please double check the URL or try submitting
       the form again.
     failure_when_not_signed_in: Please sign in to continue.
-    failure_when_missing_email: Email can’t be blank.
+    failure_when_missing_email: Email can't be blank.
   helpers:
     label:
       password:

--- a/spec/controllers/passwords_controller_spec.rb
+++ b/spec/controllers/passwords_controller_spec.rb
@@ -53,7 +53,7 @@ describe Clearance::PasswordsController do
           password: {},
         }
 
-        expect(flash.now[:alert]).to match(/email can’t be blank/i)
+        expect(flash.now[:alert]).to match(/email can't be blank/i)
         expect(response).to render_template(:new)
       end
 
@@ -74,7 +74,7 @@ describe Clearance::PasswordsController do
           },
         }
 
-        expect(flash.now[:alert]).to match(/email can’t be blank/i)
+        expect(flash.now[:alert]).to match(/email can't be blank/i)
         expect(response).to render_template(:new)
       end
 
@@ -278,7 +278,7 @@ describe Clearance::PasswordsController do
           new_password: "",
         )
 
-        expect(flash.now[:alert]).to match(/password can’t be blank/i)
+        expect(flash.now[:alert]).to match(/password can't be blank/i)
         expect(response).to have_http_status(:unprocessable_entity)
         expect(response).to render_template(:edit)
       end


### PR DESCRIPTION
Reverts thoughtbot/clearance#1006

This change has been [reverted in Rails](https://github.com/thoughtbot/clearance/pull/1006#issuecomment-2004271961).