### PR TITLE
Update specs to match on translations

### DIFF
--- a/spec/controllers/passwords_controller_spec.rb
+++ b/spec/controllers/passwords_controller_spec.rb
@@ -33,7 +33,7 @@ describe Clearance::PasswordsController do
         }
 
         email = ActionMailer::Base.deliveries.last
-        expect(email.subject).to match(/change your password/i)
+        expect(email.subject).to match(translated_string("passwords.edit.title"))
       end
 
       it "re-renders the page when turbo is enabled" do
@@ -53,7 +53,7 @@ describe Clearance::PasswordsController do
           password: {},
         }
 
-        expect(flash.now[:alert]).to match(/email can't be blank/i)
+        expect(flash.now[:alert]).to match(translated_string("flashes.failure_when_missing_email"))
         expect(response).to render_template(:new)
       end
 
@@ -74,7 +74,7 @@ describe Clearance::PasswordsController do
           },
         }
 
-        expect(flash.now[:alert]).to match(/email can't be blank/i)
+        expect(flash.now[:alert]).to match(translated_string("flashes.failure_when_missing_email"))
         expect(response).to render_template(:new)
       end
 
@@ -164,7 +164,7 @@ describe Clearance::PasswordsController do
         }
 
         expect(response).to render_template(:new)
-        expect(flash.now[:alert]).to match(/double check the URL/i)
+        expect(flash.now[:alert]).to match(translated_string("flashes.failure_when_forbidden"))
       end
     end
 
@@ -178,7 +178,7 @@ describe Clearance::PasswordsController do
         }
 
         expect(response).to render_template(:new)
-        expect(flash.now[:alert]).to match(/double check the URL/i)
+        expect(flash.now[:alert]).to match(translated_string("flashes.failure_when_forbidden"))
       end
     end
 
@@ -278,7 +278,7 @@ describe Clearance::PasswordsController do
           new_password: "",
         )
 
-        expect(flash.now[:alert]).to match(/password can't be blank/i)
+        expect(flash.now[:alert]).to match(translated_string("flashes.failure_after_update"))
         expect(response).to have_http_status(:unprocessable_entity)
         expect(response).to render_template(:edit)
       end

--- a/spec/controllers/permissions_controller_spec.rb
+++ b/spec/controllers/permissions_controller_spec.rb
@@ -58,7 +58,7 @@ describe PermissionsController do
     it "denies access to show and display a flash message" do
       get :show
 
-      expect(flash[:alert]).to match(/^Please sign in to continue/)
+      expect(flash[:alert]).to match(translated_string("flashes.failure_when_not_signed_in"))
     end
   end
 

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -41,7 +41,7 @@ describe Clearance::SessionsController do
         }
 
         expect(response).to render_template(:new)
-        expect(flash[:alert]).to match(/^Bad email or password/)
+        expect(flash[:alert]).to match(translated_string("flashes.failure_after_create"))
       end
     end
 

--- a/spec/support/html_escape_helper.rb
+++ b/spec/support/html_escape_helper.rb
@@ -1,0 +1,13 @@
+module HTMLEscapeHelper
+  def translated_string(key)
+    if Rails.version >= "7.0"
+      ERB::Util.html_escape_once(I18n.t(key))
+    else
+      I18n.t(key)
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.include HTMLEscapeHelper
+end


### PR DESCRIPTION
In Rails 7.13.1 and 7.0.8.1, a XSS vulnerability was closed that updated how translated strings are dealth with.
https://github.com/advisories/GHSA-9822-6m93-xqf4

This change to specs updates how we verify acceptance (using the translation instead of a regex) and also adds in a helper to conditionally html escape the string based on the Rails version.