### PR TITLE
Fix test deprecation warnings

### DIFF
--- a/spec/dummy/application.rb
+++ b/spec/dummy/application.rb
@@ -9,7 +9,9 @@ module Dummy
     config.action_controller.perform_caching = false
     config.action_mailer.default_url_options = { host: "dummy.example.com" }
     config.action_mailer.delivery_method = :test
-    config.active_record.legacy_connection_handling = false
+    if Rails.version.match?(/(6.1|7.0)/)
+      config.active_record.legacy_connection_handling = false
+    end
     config.active_support.deprecation = :stderr
     config.eager_load = false
 

--- a/spec/dummy/application.rb
+++ b/spec/dummy/application.rb
@@ -9,6 +9,7 @@ module Dummy
     config.action_controller.perform_caching = false
     config.action_mailer.default_url_options = { host: "dummy.example.com" }
     config.action_mailer.delivery_method = :test
+    config.active_record.legacy_connection_handling = false
     config.active_support.deprecation = :stderr
     config.eager_load = false
 

--- a/spec/generators/clearance/install/install_generator_spec.rb
+++ b/spec/generators/clearance/install/install_generator_spec.rb
@@ -66,7 +66,7 @@ describe Clearance::Generators::InstallGenerator, :generator do
         table_does_not_exist(:users)
 
         run_generator
-        migration = migration_file("db/migrate/create_users.rb")
+        migration = Pathname.new(migration_file("db/migrate/create_users.rb"))
 
         expect(migration).to exist
         expect(migration).to have_correct_syntax
@@ -88,7 +88,7 @@ describe Clearance::Generators::InstallGenerator, :generator do
           table_does_not_exist(:users)
 
           run_generator
-          migration = migration_file("db/migrate/create_users.rb")
+          migration = Pathname.new(migration_file("db/migrate/create_users.rb"))
 
           expect(migration).to exist
           expect(migration).to have_correct_syntax
@@ -102,8 +102,8 @@ describe Clearance::Generators::InstallGenerator, :generator do
         provide_existing_application_controller
 
         run_generator
-        create_migration = migration_file("db/migrate/create_users.rb")
-        add_migration = migration_file("db/migrate/add_clearance_to_users.rb")
+        create_migration = Pathname.new(migration_file("db/migrate/create_users.rb"))
+        add_migration = Pathname.new(migration_file("db/migrate/add_clearance_to_users.rb"))
 
         expect(create_migration).not_to exist
         expect(add_migration).not_to exist
@@ -126,7 +126,7 @@ describe Clearance::Generators::InstallGenerator, :generator do
           and_return(existing_indexes)
 
         run_generator
-        migration = migration_file("db/migrate/add_clearance_to_users.rb")
+        migration = Pathname.new(migration_file("db/migrate/add_clearance_to_users.rb"))
 
         expect(migration).to exist
         expect(migration).to have_correct_syntax

--- a/spec/generators/clearance/install/install_generator_spec.rb
+++ b/spec/generators/clearance/install/install_generator_spec.rb
@@ -2,6 +2,10 @@ require "spec_helper"
 require "generators/clearance/install/install_generator"
 
 describe Clearance::Generators::InstallGenerator, :generator do
+  def get_migration(path)
+    Pathname.new(migration_file(path))
+  end
+
   describe "initializer" do
     it "is copied to the application" do
       provide_existing_application_controller
@@ -66,7 +70,7 @@ describe Clearance::Generators::InstallGenerator, :generator do
         table_does_not_exist(:users)
 
         run_generator
-        migration = Pathname.new(migration_file("db/migrate/create_users.rb"))
+        migration = get_migration("db/migrate/create_users.rb")
 
         expect(migration).to exist
         expect(migration).to have_correct_syntax
@@ -88,7 +92,7 @@ describe Clearance::Generators::InstallGenerator, :generator do
           table_does_not_exist(:users)
 
           run_generator
-          migration = Pathname.new(migration_file("db/migrate/create_users.rb"))
+          migration = get_migration("db/migrate/create_users.rb")
 
           expect(migration).to exist
           expect(migration).to have_correct_syntax
@@ -102,8 +106,8 @@ describe Clearance::Generators::InstallGenerator, :generator do
         provide_existing_application_controller
 
         run_generator
-        create_migration = Pathname.new(migration_file("db/migrate/create_users.rb"))
-        add_migration = Pathname.new(migration_file("db/migrate/add_clearance_to_users.rb"))
+        create_migration = get_migration("db/migrate/create_users.rb")
+        add_migration = get_migration("db/migrate/add_clearance_to_users.rb")
 
         expect(create_migration).not_to exist
         expect(add_migration).not_to exist
@@ -126,7 +130,7 @@ describe Clearance::Generators::InstallGenerator, :generator do
           and_return(existing_indexes)
 
         run_generator
-        migration = Pathname.new(migration_file("db/migrate/add_clearance_to_users.rb"))
+        migration = get_migration("db/migrate/add_clearance_to_users.rb")
 
         expect(migration).to exist
         expect(migration).to have_correct_syntax


### PR DESCRIPTION
**This PR:**
- Addresses two different deprecation warnings that appear when running tests:

```
DEPRECATION WARNING: The `exist` matcher overrides one built-in by RSpec; 
use `expect(Pathname.new(path)).to exist` instead
```

```
DEPRECATION WARNING: Using legacy connection handling is deprecated. 
Please set `legacy_connection_handling` to `false` in your application.
```