### PR TITLE
Fix method redefinition and circular require issues

### DIFF
--- a/lib/clearance.rb
+++ b/lib/clearance.rb
@@ -5,9 +5,9 @@ require 'clearance/rack_session'
 require 'clearance/back_door'
 require 'clearance/controller'
 require 'clearance/user'
-require 'clearance/engine'
 require 'clearance/password_strategies'
 require 'clearance/constraints'
+require 'clearance/engine'
 
 module Clearance
 end

--- a/lib/clearance/configuration.rb
+++ b/lib/clearance/configuration.rb
@@ -135,7 +135,7 @@ module Clearance
     # The parameter for user routes. By default this is derived from the user
     # model.
     # @return [Symbol]
-    attr_accessor :user_parameter
+    attr_writer :user_parameter
 
     # Controls wether users are automatically signed in after successfully
     # resetting their password.

--- a/lib/clearance/engine.rb
+++ b/lib/clearance/engine.rb
@@ -1,4 +1,3 @@
-require "clearance"
 require "rails/engine"
 
 module Clearance


### PR DESCRIPTION
https://github.com/thoughtbot/clearance/issues/999

This PR addresses two issues:

1. **Method Redefinition:** The `user_parameter` method was being defined multiple times in `lib/clearance/configuration.rb`. This has been fixed by changing `attr_accessor` to `attr_writer`, ensuring the method is defined only once.

2. **Circular Require:** Circular dependencies between `lib/clearance.rb` and `lib/clearance/engine.rb` have been resolved by rearranging the require statements to avoid circular loading.