### PR TITLE
Fix query params being clobbered by Clearance::BackDoor

### DIFF
--- a/lib/clearance/back_door.rb
+++ b/lib/clearance/back_door.rb
@@ -54,7 +54,6 @@ module Clearance
       if user_param.present?
         query_string = Rack::Utils.build_query(params)
         env[Rack::QUERY_STRING] = query_string
-        env[Rack::RACK_REQUEST_QUERY_STRING] = query_string
         user = find_user(user_param)
         env[:clearance].sign_in(user)
       end

--- a/spec/dummy/app/controllers/application_controller.rb
+++ b/spec/dummy/app/controllers/application_controller.rb
@@ -2,6 +2,6 @@ class ApplicationController < ActionController::Base
   include Clearance::Controller
 
   def show
-    render inline: "Hello user #<%= current_user.id %>", layout: false
+    render inline: "Hello user #<%= current_user.id %> #{params.to_json}", layout: false
   end
 end

--- a/spec/requests/backdoor_spec.rb
+++ b/spec/requests/backdoor_spec.rb
@@ -8,4 +8,12 @@ describe "Backdoor Middleware" do
 
     expect(cookies["remember_token"]).to eq user.remember_token
   end
+
+  it "removes the `as` param but leaves other parameters unchanged" do
+    user = create(:user)
+
+    get root_path(as: user.to_param, foo: 'bar')
+
+    expect(response.body).to include('{"foo":"bar","controller":"application","action":"show"}')
+  end
 end


### PR DESCRIPTION
In rack 3.1.x Setting Rack::RACK_REQUEST_QUERY_STRING causes rack to think
that the query string has already been parsed
(see https://github.com/rack/rack/blob/v3.1.7/lib/rack/request.rb#L487)

This was introduced in #2703 but wasn't actually necessary - the warning mentioned
in that PR is only triggered if only Rack::RACK_REQUEST_QUERY_STRING is updated,
but the correct behaviour is to only set Rack::QUERY_STRING, not to set both

Fixes #1040
