### PR TITLE
normalize blank emails to nil

### DIFF
--- a/lib/clearance/user.rb
+++ b/lib/clearance/user.rb
@@ -127,6 +127,7 @@ module Clearance
       end
 
       def normalize_email(email)
+        return if email.blank?
         email.to_s.downcase.gsub(/\s+/, "")
       end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -75,7 +75,9 @@ describe User do
 
       expect(user_does_not_exist_time). to be_within(0.01).of(user_exists_time)
     end
+  end
 
+  describe ".find_by_normalized_email" do
     it "is retrieved via a case-insensitive search" do
       user = create(:user)
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -174,6 +174,14 @@ describe User do
     it { is_expected.to allow_value(nil).for(:email) }
     it { is_expected.to allow_value("").for(:email) }
 
+    it "converts blank emails to nil" do
+      [nil, "", "   "].each do |blank_email|
+        subject.email = blank_email
+        subject.valid?
+        expect(subject.email).to be_nil
+      end
+    end
+
     def user
       @user ||= User.new
       allow(@user).to receive(:email_optional?).and_return(true)


### PR DESCRIPTION
I noticed that `Clearance::User.normalize_email` will convert nil to an empty string, since it always calls `to_s` on it.
I think normalizing an email that is blank should convert it to nil.

In my app, I want to allow empty emails but still validate their uniqueness, if an email is given. This only works when empty emails are stored as nil, not as an empty string, which is the current behavior.