### PR TITLE
Replace obsolete unprocessable_entity with unprocessable_content

### DIFF
--- a/app/controllers/clearance/passwords_controller.rb
+++ b/app/controllers/clearance/passwords_controller.rb
@@ -38,7 +38,7 @@ class Clearance::PasswordsController < Clearance::BaseController
       session[:password_reset_token] = nil
     else
       flash_failure_after_update
-      render template: "passwords/edit", status: :unprocessable_entity
+      render template: "passwords/edit", status: :unprocessable_content
     end
   end
 
@@ -80,14 +80,14 @@ class Clearance::PasswordsController < Clearance::BaseController
   def ensure_email_present
     if email_from_password_params.blank?
       flash_failure_when_missing_email
-      render template: "passwords/new", status: :unprocessable_entity
+      render template: "passwords/new", status: :unprocessable_content
     end
   end
 
   def ensure_existing_user
     unless find_user_by_id_and_confirmation_token
       flash_failure_when_forbidden
-      render template: "passwords/new", status: :unprocessable_entity
+      render template: "passwords/new", status: :unprocessable_content
     end
   end
 

--- a/app/controllers/clearance/users_controller.rb
+++ b/app/controllers/clearance/users_controller.rb
@@ -14,7 +14,7 @@ class Clearance::UsersController < Clearance::BaseController
       sign_in @user
       redirect_back_or url_after_create
     else
-      render template: "users/new", status: :unprocessable_entity
+      render template: "users/new", status: :unprocessable_content
     end
   end
 

--- a/spec/controllers/passwords_controller_spec.rb
+++ b/spec/controllers/passwords_controller_spec.rb
@@ -62,7 +62,7 @@ describe Clearance::PasswordsController do
           password: {}
         }
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
     end
 
@@ -85,7 +85,7 @@ describe Clearance::PasswordsController do
           }
         }
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
     end
 
@@ -279,7 +279,7 @@ describe Clearance::PasswordsController do
         )
 
         expect(flash.now[:alert]).to match(I18n.t("flashes.failure_after_update"))
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(response).to render_template(:edit)
       end
 

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -78,7 +78,7 @@ describe Clearance::UsersController do
           }
 
           expect(User.count).to eq old_user_count
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
         end
       end
     end


### PR DESCRIPTION
This change replaces all instances of :unprocessable_entity with :unprocessable_content.

In keeping aligned with the IANA HTTP Status Code Registry, Rack deprecated unprocessable_entity for unprocessable_content. They still include handling for the time being but have included a deprecation notice.

More info: https://github.com/rack/rack/pull/2137