### PR TITLE
Upgrade Ruby and Rails versions

### DIFF
--- a/.github/workflows/standardrb.yml
+++ b/.github/workflows/standardrb.yml
@@ -15,5 +15,5 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-          ruby-version: 3.2.9
+          ruby-version: 3.3.11
       - run: bundle exec standardrb --format github --parallel

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,13 +16,13 @@ jobs:
       fail-fast: false
       matrix:
         gemfile:
-          - "7.1"
           - "7.2"
           - "8.0"
+          - "8.1"
         ruby:
-          - "3.2.9"
-          - "3.3.9"
-          - "3.4.5"
+          - "3.3.11"
+          - "3.4.9"
+          - "4.0.2"
 
     env:
       BUNDLE_GEMFILE: gemfiles/rails_${{ matrix.gemfile }}.gemfile

--- a/Appraisals
+++ b/Appraisals
@@ -1,7 +1,3 @@
-appraise "rails_7.1" do
-  gem "railties", "~> 7.1.0"
-end
-
 appraise "rails_7.2" do
   gem "railties", "~> 7.2.0"
 end
@@ -9,4 +5,7 @@ end
 appraise "rails_8.0" do
   gem "railties", "~> 8.0.0"
   gem "sqlite3", ">= 2.1"
+end
+appraise "rails_8.1" do
+  gem "railties", "~> 8.1.0"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gemspec
 gem "addressable"
 gem "ammeter"
 gem "appraisal"
+gem "benchmark"
 gem "capybara"
 gem "database_cleaner"
 gem "erb_lint", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -294,6 +294,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-24
+  arm64-darwin-25
   x86_64-linux
 
 DEPENDENCIES

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -185,7 +185,7 @@ GEM
       stringio
     public_suffix (6.0.2)
     racc (1.8.1)
-    rack (3.2.3)
+    rack (3.2.6)
     rack-session (2.1.1)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
@@ -301,6 +301,7 @@ DEPENDENCIES
   addressable
   ammeter
   appraisal
+  benchmark
   capybara
   clearance!
   database_cleaner

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ monitored by contributors.
 
 ## Getting Started
 
-Clearance is a Rails engine tested against Rails `>= 7.1` and Ruby `>= 3.2.9`.
+Clearance is a Rails engine tested against Rails `>= 7.2` and Ruby `>= 3.3.11`.
 
 You can add it to your Gemfile with:
 

--- a/clearance.gemspec
+++ b/clearance.gemspec
@@ -29,7 +29,8 @@ Gem::Specification.new do |s|
     "Galen Frechette",
     "Josh Steiner",
     "Dorian Marié",
-    "Sara Jackson"
+    "Sara Jackson",
+    "Fernando Perales"
   ]
   s.description = <<-DESCRIPTION
     Clearance is built to support authentication and authorization via an
@@ -46,7 +47,7 @@ Gem::Specification.new do |s|
   s.name = "clearance"
   s.rdoc_options = ["--charset=UTF-8"]
   s.require_paths = ["lib"]
-  s.required_ruby_version = Gem::Requirement.new(">= 3.1.6")
+  s.required_ruby_version = Gem::Requirement.new(">= 3.3.11")
   s.summary = "Rails authentication & authorization with email & password."
   s.version = Clearance::VERSION
 end

--- a/gemfiles/rails_7.2.gemfile
+++ b/gemfiles/rails_7.2.gemfile
@@ -9,13 +9,13 @@ gem "capybara"
 gem "database_cleaner"
 gem "erb_lint", require: false
 gem "factory_bot_rails"
-gem "ffi", "< 1.17.0"
+gem "ffi", "< 1.18.0"
 gem "nokogiri"
 gem "pry", require: false
 gem "rails-controller-testing"
 gem "rspec-rails"
 gem "shoulda-matchers"
-gem "sqlite3", "~> 1.7"
+gem "sqlite3", "~> 2.8"
 gem "standard", ">= 1.35.1", require: false
 gem "timecop"
 gem "railties", "~> 7.2.0"

--- a/gemfiles/rails_7.2.gemfile
+++ b/gemfiles/rails_7.2.gemfile
@@ -5,6 +5,7 @@ source "https://rubygems.org"
 gem "addressable"
 gem "ammeter"
 gem "appraisal"
+gem "benchmark"
 gem "capybara"
 gem "database_cleaner"
 gem "erb_lint", require: false

--- a/gemfiles/rails_8.0.gemfile
+++ b/gemfiles/rails_8.0.gemfile
@@ -9,16 +9,15 @@ gem "capybara"
 gem "database_cleaner"
 gem "erb_lint", require: false
 gem "factory_bot_rails"
-gem "ffi", "< 1.17.0"
+gem "ffi", "< 1.18.0"
 gem "nokogiri"
 gem "pry", require: false
 gem "rails-controller-testing"
 gem "rspec-rails"
 gem "shoulda-matchers"
-gem "sqlite3", "~> 2.1"
+gem "sqlite3", ">= 2.1"
 gem "standard", ">= 1.35.1", require: false
 gem "timecop"
 gem "railties", "~> 8.0.0"
-gem "net-smtp", require: false
 
 gemspec path: "../"

--- a/gemfiles/rails_8.0.gemfile
+++ b/gemfiles/rails_8.0.gemfile
@@ -5,6 +5,7 @@ source "https://rubygems.org"
 gem "addressable"
 gem "ammeter"
 gem "appraisal"
+gem "benchmark"
 gem "capybara"
 gem "database_cleaner"
 gem "erb_lint", require: false

--- a/gemfiles/rails_8.1.gemfile
+++ b/gemfiles/rails_8.1.gemfile
@@ -5,6 +5,7 @@ source "https://rubygems.org"
 gem "addressable"
 gem "ammeter"
 gem "appraisal"
+gem "benchmark"
 gem "capybara"
 gem "database_cleaner"
 gem "erb_lint", require: false

--- a/gemfiles/rails_8.1.gemfile
+++ b/gemfiles/rails_8.1.gemfile
@@ -9,15 +9,15 @@ gem "capybara"
 gem "database_cleaner"
 gem "erb_lint", require: false
 gem "factory_bot_rails"
-gem "ffi", "< 1.17.0"
+gem "ffi", "< 1.18.0"
 gem "nokogiri"
 gem "pry", require: false
 gem "rails-controller-testing"
 gem "rspec-rails"
 gem "shoulda-matchers"
-gem "sqlite3", "~> 1.7"
+gem "sqlite3", "~> 2.8"
 gem "standard", ">= 1.35.1", require: false
 gem "timecop"
-gem "railties", "~> 7.1.0"
+gem "railties", "~> 8.1.0"
 
 gemspec path: "../"


### PR DESCRIPTION
* Remove Ruby 3.2.9
* Bump ruby 3.3.9 to 3.3.11
* Make ruby 3.3.11 the minimum required version
* Bump ruby 3.4.5 to 3.4.9
* Add ruby 4.0.2
* Remove RoR 7.1.0 support
* Add RoR 8.1.0 support