### PR TITLE
Add missing permissions to GitHub Actions jobs

### DIFF
--- a/.github/workflows/standardrb.yml
+++ b/.github/workflows/standardrb.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   standardrb:
     name: StandardRB
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   test:
     name: "Ruby ${{ matrix.ruby }}, Rails ${{ matrix.gemfile }}"
+    permissions:
+      contents: read
+      pull-requests: write
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
codeql and tests GitHub Actions jobs did not have permissions set.